### PR TITLE
MOS-002 build and push docker images vers 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 dist
+*.pem

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,19 +5,19 @@ services:
   proxy:
     depends_on: 
       - frontend
-    image: patricksyoung/mosaic-proxy:1.1
+    image: patricksyoung/mosaic-proxy:2.0
     ports:
       - '80:80'
     networks:
       - mosaic-network
 
   frontend:
-    image: patricksyoung/mosaic-frontend:latest
+    image: patricksyoung/mosaic-frontend:2.0
     networks:
       - mosaic-network
 
   backend:
-    image: patricksyoung/mosaic-backend:1.1
+    image: patricksyoung/mosaic-backend:2.0
     depends_on:
       - api
     volumes:
@@ -26,7 +26,7 @@ services:
       - mosaic-network
 
   api:
-    image: patricksyoung/mosaic-api:1.4
+    image: patricksyoung/mosaic-api:2.0
     volumes:
       - mosaic-volume:/var/lib/video
     networks:

--- a/mosaic-frontend/Dockerfile
+++ b/mosaic-frontend/Dockerfile
@@ -1,13 +1,10 @@
-#build stage for a Node.js application
-FROM node:lts-alpine as build-stage
+FROM node:13.12.0-alpine AS build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . ./
 RUN npm run build
-
-#production stage
-FROM nginx:stable-alpine as production-stage
+FROM nginx:stable-alpine AS production-stage
 EXPOSE 3000
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=build-stage /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## Description
Fixes # MOS-002 update and push dockerhub images
- Running docker compose with legacy dockerhub images results in the display of a dummy UI used in an earlier stage of the project. 
- A newer, production-ready UI is what is expected (see screenshot). 
- To assure that docker images represent code in current repository, new images were built and pushed with '2.0' tag.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually test by running _docker compose up_ locally. Frontend is loading with expected UI. Further discovery needed to enabled video upload and processing on localhost.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

#Screenshots
![mos-002](https://github.com/user-attachments/assets/07e92288-dd0b-49ba-a9cf-2ec40e0671d5)
