### PR TITLE
MOS-008 desktop display dynamic font size

### DIFF
--- a/mosaic-frontend/src/devTools/AssignDisplay/desktopDisplay.scss
+++ b/mosaic-frontend/src/devTools/AssignDisplay/desktopDisplay.scss
@@ -2,12 +2,13 @@
   box-sizing: border-box;
   display: flex;
   width: 100%;
-  padding: 20px 40px;
+  padding: 20px 0px;
 
   > div {
     box-sizing: border-box;
     display: flex;
     width: 100%;
+    padding: 0px 40px;
   }
 
   ul {
@@ -35,9 +36,9 @@
   }
 
   &__leftColumn {
-    font-size: 24px;
+    width: 33vw;
+    font-size: 2vh;
     flex-direction: column;
-
   }
 
   &__middleColumn {
@@ -48,7 +49,7 @@
     justify-content: flex-end;
     gap: 40px;
     > div {
-      color: blue;
+      color:#7b1fa2;
       font-size: 24px;
       font-weight: 600;
     }


### PR DESCRIPTION

## Description

Fixes MOS-008 desktop display overlapping layout
- Adjusted font-size to 2vh
- Added horizontal padding to left, middle, and right columns

## Screens

BEFORE:
![MOS-008-before](https://github.com/user-attachments/assets/e0ec9ac5-09c8-4add-8933-28888e20d4e6)

AFTER:

![MOS-008-after](https://github.com/user-attachments/assets/efd62da5-cb8c-44df-91be-fc52482dd0a3)
