### PR TITLE
MOS-009 pop over not covering all UI

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
   proxy:

--- a/docker-compose-frontend-dev.yaml
+++ b/docker-compose-frontend-dev.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
   proxy:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
   proxy:

--- a/mosaic-frontend/src/app/app.config.ts
+++ b/mosaic-frontend/src/app/app.config.ts
@@ -1,11 +1,14 @@
 import isMobile from 'is-mobile';
 
+
 const [width, uiContainerHeight] = isMobile({ tablet: true }) 
   ? [window.innerWidth, window.innerHeight - window.innerWidth] 
   : [414, 302];
 
+const popOverHeight = width + uiContainerHeight;
+
 export const appDimensions = {
-  popOver: { width, height: 580 },
+  popOver: { width, height: popOverHeight },
   videoArea: { width, height: width },
   scrubberSlider: { width, height: 90 },
   mosaicSelector: { width, height: 72 },

--- a/mosaic-frontend/src/devTools/AssignDisplay/DesktopDisplay.tsx
+++ b/mosaic-frontend/src/devTools/AssignDisplay/DesktopDisplay.tsx
@@ -1,4 +1,3 @@
-import { Grid } from '@material-ui/core';
 import iPhone_XR from '@assets/device-preview/iPhone_XR_mock_414x712.png';
 import './desktopDisplay.scss';
 


### PR DESCRIPTION
## Description

Fixes # MOS-009 pop over not covering all UI
- Update app.config.ts to set popOver.height to 'width + uiContainerHeight'. This fixes both device and desktop displays
- Remove deprecated 'version' in docker compose scripts
- Remove unused Grid import in DesktopDisplay.tsx



## Screenshots

BEFORE:
![MOS-009-before](https://github.com/user-attachments/assets/7cb5628c-49a4-4427-9267-730cbc56f091)


AFTER:

![MOS-009-after](https://github.com/user-attachments/assets/5d6899ff-9425-46f2-b671-6debef13ac82)

