### PR TITLE
MOS-011 update prox config to include loading.gif

### DIFF
--- a/mosaic-proxy/default.conf
+++ b/mosaic-proxy/default.conf
@@ -15,7 +15,11 @@ server {
         proxy_pass http://frontend;
     }
 
-    location /uploads{
+    location /ui {
+        proxy_pass http://frontend;
+    }
+
+    location /uploads {
         proxy_pass http://backend/uploads;
     }
 


### PR DESCRIPTION


## Description

Fixes MOS-011 loading.gif broken link
- Update reverse proxy config to route '/ui' location to frontend container


## How Has This Been Tested?
- Rebuilt images for mosaic-proxy and tested locally with throttled bandwidth

