### PR TITLE
MOS-130 replace mui selector buttons with sass

### DIFF
--- a/mosaic-frontend/src/components/FileIOPrompt/promptButton.scss
+++ b/mosaic-frontend/src/components/FileIOPrompt/promptButton.scss
@@ -5,8 +5,8 @@
 .promptButton {
   width: 140px;
   height: $size-bttn-small;
-  background: $mosaic-button-default;
-  color: $mosaic-button-text-default;
+  background: $button-background-default;
+  color: $button-color-default;
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -14,15 +14,15 @@
   gap: $spacing-space-16;
   text-wrap: nowrap;
   cursor: pointer;
-  border-radius: $radius-radious-12;
-  border: 1px solid $mosaic-purple-light;
+  border-radius: $button-border-radius;
+  border: $button-border-default;
   @include dropShadow-1();
   @include font-style($size: 18px, $weight: 500, $transform: uppercase, $lineHeight: 0.5);
 
   &:hover {
-    @include state-hover-default($surface: $mosaic-button-default, $state: $mosaic-button-hover);
+    @include state-hover-default($surface: $button-background-default, $state: $button-background-hover);
   }
   &:active {
-    @include state-pressed-default($surface: $mosaic-button-default, $state: $mosaic-button-pressed);
+    @include state-pressed-default($surface: $button-background-default, $state: $button-background-pressed);
   }
 }

--- a/mosaic-frontend/src/components/MosaicSelector/MosaicSelectorButton.tsx
+++ b/mosaic-frontend/src/components/MosaicSelector/MosaicSelectorButton.tsx
@@ -8,11 +8,12 @@ const MosaicSelectorButton: React.FC<MosaicSelectorButtonProps> = ({ numTiles, w
   const buttonClass = isSelected 
     ? 'mosaicSelectorButton mosaicSelectorButton--selected' 
     : 'mosaicSelectorButton';
+  const buttonHeight = width * .9;
     
   return (
     <button 
       className={buttonClass} 
-      style={{ width, height: width }}
+      style={{ width, height: buttonHeight }}
       onClick={() => onClick(numTiles)}
     >
       {React.createElement(mosaicIcons[numTiles])}

--- a/mosaic-frontend/src/components/MosaicSelector/mosaicSelector.scss
+++ b/mosaic-frontend/src/components/MosaicSelector/mosaicSelector.scss
@@ -5,5 +5,6 @@
   display: flex;
   justify-content: space-between;
   z-index: 10;
+  gap: $spacing-space-12;
   padding: 0 10px 0 10px;
 }

--- a/mosaic-frontend/src/components/MosaicSelector/mosaicSelectorButton.icons.tsx
+++ b/mosaic-frontend/src/components/MosaicSelector/mosaicSelectorButton.icons.tsx
@@ -3,45 +3,72 @@ import type { MosaicIconProps } from "@interfaces/MosaicIconProps";
 
 const Mosaic2: React.FC<MosaicIconProps> = () => {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" width="24" height="24"></rect>
-      <path d="M11.026216,4 L11.026216,19.9995069 L3.98776023,19.9995069 L3.98776023,4 L11.026216,4 Z M20.0384558,4 L20.0384558,19.9995069 L13,19.9995069 L13,4 L20.0384558,4 Z" id="Shape" fill="#FFFFFF"></path>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="24" height="24" strokeWidth="8"  fill="none"></rect>
+      <path
+        strokeWidth="2"
+        stroke="currentColor"
+        d="M 12,0 v 23"
+      />
     </svg>
   )
 }
 
 const Mosaic3: React.FC<MosaicIconProps> = () => {
   return (  
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" width="24" height="24"></rect>
-      <path d="M8,4 L8,20 L4,20 L4,4 L8,4 Z M14,4 L14,20 L10,20 L10,4 L14,4 Z M20,4 L20,20 L16,20 L16,4 L20,4 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="24" height="24" strokeWidth="8"  fill="none"></rect>
+      <path
+        strokeWidth="2"
+        stroke="currentColor"
+        d="M 9,0 v 23
+        M 15,0 v 23"
+      />
     </svg>
   )
 }
 
 const Mosaic4: React.FC<MosaicIconProps> = () => {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" width="24" height="24"></rect>
-      <path d="M11,13 L11,20 L4,20 L4,13 L11,13 Z M20,13 L20,20 L13,20 L13,13 L20,13 Z M20,4 L20,11 L13,11 L13,4 L20,4 Z M11,4 L11,11 L4,11 L4,4 L11,4 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="24" height="24" strokeWidth="8"  fill="none"></rect>
+      <path
+        strokeWidth="2"
+        stroke="currentColor"
+        d="M 0,12 h 23
+        M 12,0 v 23"
+      />
     </svg>
   )
 }
 
 const Mosaic6: React.FC<MosaicIconProps> = () => {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" width="24" height="24"></rect>
-      <path d="M8,13 L8,20 L4,20 L4,13 L8,13 Z M14,13 L14,20 L10,20 L10,13 L14,13 Z M20,13 L20,20 L16,20 L16,13 L20,13 Z M8,4 L8,11 L4,11 L4,4 L8,4 Z M14,4 L14,11 L10,11 L10,4 L14,4 Z M20,4 L20,11 L16,11 L16,4 L20,4 Z" id="Shape" fill="#FFFFFF"></path>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="24" height="24" strokeWidth="8"  fill="none"></rect>
+      <path
+        strokeWidth="2"
+        stroke="currentColor"
+        d="M 0,12 h 23
+        M 9,0 v 23
+        M 15,0 v 23"
+      />
     </svg>
   )
 }
 
 const Mosaic9: React.FC<MosaicIconProps> = () => {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" width="24" height="24"></rect>
-      <path d="M8,16 L8,20 L4,20 L4,16 L8,16 Z M14,16 L14,20 L10,20 L10,16 L14,16 Z M20,16 L20,20 L16,20 L16,16 L20,16 Z M8,10 L8,14 L4,14 L4,10 L8,10 Z M14,10 L14,14 L10,14 L10,10 L14,10 Z M20,10 L20,14 L16,14 L16,10 L20,10 Z M8,4 L8,8 L4,8 L4,4 L8,4 Z M14,4 L14,8 L10,8 L10,4 L14,4 Z M20,4 L20,8 L16,8 L16,4 L20,4 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="24" height="24" strokeWidth="8"  fill="none"></rect>
+      <path
+        strokeWidth="2"
+        stroke="currentColor"
+        d="M 0,9 h 23
+        M 0,15 h 23
+        M 9,0 v 23
+        M 15,0 v 23"
+      />
     </svg>
   )
 }

--- a/mosaic-frontend/src/components/MosaicSelector/mosaicSelectorButton.scss
+++ b/mosaic-frontend/src/components/MosaicSelector/mosaicSelectorButton.scss
@@ -3,37 +3,47 @@
 
 .mosaicSelectorButton {
   box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: none;
   cursor: pointer;
-  background-color: transparent;
+  @include dropShadow-0-5();
+  border-radius: $button-border-radius;
+  border: $button-border-light;
+  background: $button-color-default; 
 
   svg {
-    width: 100%;
-    height: auto;
-    fill: $button-icon-default; 
-    box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.30), 0px 2px 6px 2px rgba(0, 0, 0, 0.25);
+    width: 75%;
+    height: auto; 
+    rect, path {
+      stroke: $button-background-default; 
+    }
   }
 
   &:hover {
     svg {
-      fill: $button-icon-hover;
-      transition: fill 0.3s ease;
-      box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.30), 0px 2px 6px 2px rgba(0, 0, 0, 0.25);
-      transition: box-shadow 0.4s ease;
+      rect, path {
+        stroke: $button-background-hover;
+      }
     }
+    background: $button-background-default;
   }
 
   &:active {
     svg {
       fill: $button-icon-pressed;
-      box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.50), 0px 2px 6px 2px rgba(0, 0, 0, 0.45);
     }
+    @include dropShadow-2();
   }
   
   &--selected {
     svg {
-      fill: $button-icon-pressed;
-      box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.50), 0px 2px 6px 2px rgba(0, 0, 0, 0.45);
+      rect, path {
+        stroke: $button-background-hover;
+      }
     }
+    background: $button-background-default;
+    @include dropShadow-2();
   }
 }

--- a/mosaic-frontend/src/sass/mosaicMixins.scss
+++ b/mosaic-frontend/src/sass/mosaicMixins.scss
@@ -65,6 +65,6 @@ $font-stack: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ox
 
 @mixin state-pressed-default($surface: $surface-default, $state: $state-pressed-default) {
   background: linear-gradient(0deg, $state 0%, $state) 100%, $surface;
-  color: $mosaic-button-text-pressed;
+  color: $button-color-pressed;
   box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.30), 0px 2px 6px 2px rgba(0, 0, 0, 0.25);
 }

--- a/mosaic-frontend/src/sass/mosaicVariables.scss
+++ b/mosaic-frontend/src/sass/mosaicVariables.scss
@@ -8,13 +8,31 @@ $mosaic-pressed-default: rgba(30, 30, 30, 0.24);
 
 $surface-default: white;
 
-$mosaic-button-default: #7b1fa2;
-$mosaic-button-hover: #FAF8FF;
-$mosaic-button-pressed: #faf8ffc7;
+// Radius =====
+$radius-radius-2: 2px;
+$radius-radius-4: 4px;
+$radius-radious-8: 8px;
+$radius-radious-12: 12px;
+$radius-radius-16: 16px;
+$radius-radius-24: 24px;
+$radius-radius-32: 32px;
+$radius-radius-48: 48px;
+$radius-radius-96: 96px;
+$radius-radius-full: 999px;
 
-$mosaic-button-text-default: #FAF8FF;
-$mosaic-button-text-hover: #7b1fa2;
-$mosaic-button-text-pressed: #6a128f;
+// Button =====
+$button-background-default: #7b1fa2;
+$button-background-hover: #FAF8FF;
+$button-background-pressed: #faf8ffc7;
+
+$button-border-default: 1px solid $mosaic-purple-light;
+$button-border-light: 1px solid #ad52d44d;
+
+$button-color-default: #FAF8FF;
+$button-color-hover: #7b1fa2;
+$button-color-pressed: #FAF8FF;
+
+$button-border-radius: $radius-radious-12;
 
 $button-icon-default: #777575;
 $button-icon-hover: $mosaic-purple-dark;
@@ -48,17 +66,7 @@ $border-large: 3px;
 $border-medium: 2px;
 $border-small: 1px;
 
-// Radius =====
-$radius-radius-2: 2px;
-$radius-radius-4: 4px;
-$radius-radious-8: 8px;
-$radius-radious-12: 12px;
-$radius-radius-16: 16px;
-$radius-radius-24: 24px;
-$radius-radius-32: 32px;
-$radius-radius-48: 48px;
-$radius-radius-96: 96px;
-$radius-radius-full: 999px;
+
 
 // Radius Reference --
 $radius-pttn-radius-bttn-sm: $radius-radious-12;


### PR DESCRIPTION


## Description

Fixes # MOS-130.replace.mui.selector.buttons
- Replace Material-UI selector buttons with SASS

BEFORE
![Screenshot 2025-01-28 132744](https://github.com/user-attachments/assets/edbc3a86-a009-490e-bc43-610290aacd2a)



AFTER
![Screenshot 2025-01-28 132718](https://github.com/user-attachments/assets/bb95c0d5-8e26-4446-aacc-3d5608ef8d3f)
