### PR TITLE
MOS-131 replace mui nav button with sass

### DIFF
--- a/mosaic-frontend/src/components/Navigation/Navigation.tsx
+++ b/mosaic-frontend/src/components/Navigation/Navigation.tsx
@@ -3,11 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import type { RootState } from '@typescript/types';
 import { setNavPhase } from '@/components/Navigation/nav.slice';
 import { NavState } from '@interfaces/NavState';
-import { Tab, Tabs } from '@material-ui/core';
-import { SaveAlt, MovieCreation, VideoCall } from '@material-ui/icons';
 import { NavPhaseEnum } from '@enums/NavPhaseEnum';
 import { NavigationProps } from '@interfaces/NavigationProps';
 import navPhaseString from '@analytics/traceEvent.config';
+import NavigationButton from './NavigationButton';
 import './navigation.scss';
 
 
@@ -16,13 +15,8 @@ const Navigation: React.FC<NavigationProps> = ({
   pauseInput }) => {
   const dispatch = useDispatch();
   const { navPhase } = useSelector<RootState, NavState>((state) => state.nav);
-  const navigationWidth = width;
-  const tabStyle = {
-    minWidth: navigationWidth / 3,
-    backgroundColor: 'white'
-  }
 
-  const handleChange = (_: React.ChangeEvent<{}>, newValue: NavPhaseEnum) => {
+  const handleChange = (newValue: NavPhaseEnum) => {
     traceEvent({
       category: 'Navigation',
       action: navPhaseString[newValue],
@@ -32,15 +26,10 @@ const Navigation: React.FC<NavigationProps> = ({
   };
 
   return (
-    <div className='navigation' style={{ width: navigationWidth }}>
-      <Tabs
-        value={navPhase}
-        onChange={handleChange}
-      >
-        <Tab icon={<VideoCall fontSize='large' />} value={NavPhaseEnum.UPLOAD} style={tabStyle} label="UPLOAD" />
-        <Tab icon={<MovieCreation fontSize='large' />} value={NavPhaseEnum.EDIT} style={tabStyle} label="EDIT" />
-        <Tab icon={<SaveAlt fontSize='large' />} value={NavPhaseEnum.DOWNLOAD} style={tabStyle} label="SAVE" />
-      </Tabs>
+    <div className='navigation' style={{ width }}>
+      <NavigationButton label='UPLOAD' value={NavPhaseEnum.UPLOAD} activeNavPhase={navPhase} onClick={handleChange} />
+      <NavigationButton label='EDIT' value={NavPhaseEnum.EDIT} activeNavPhase={navPhase} onClick={handleChange} />
+      <NavigationButton label='SAVE' value={NavPhaseEnum.DOWNLOAD} activeNavPhase={navPhase} onClick={handleChange} />
     </div>
   );
 }

--- a/mosaic-frontend/src/components/Navigation/NavigationButton.tsx
+++ b/mosaic-frontend/src/components/Navigation/NavigationButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { NavigationButtonProps } from '@interfaces/NavigationButtonProps';
+import './navigationButton.scss';
+
+
+const NavigationButton: React.FC<NavigationButtonProps> = ({ 
+  label, 
+  value,
+  activeNavPhase, 
+  onClick}) => {
+  const buttonClass = value === activeNavPhase 
+    ? 'navigationButton navigationButton--selected' 
+    : 'navigationButton';
+
+  return (
+    <button 
+      className={buttonClass} 
+      onClick={() => onClick(value)}
+    >
+      {label}
+    </button>
+  );
+};  
+
+export default NavigationButton;

--- a/mosaic-frontend/src/components/Navigation/navigation.scss
+++ b/mosaic-frontend/src/components/Navigation/navigation.scss
@@ -1,17 +1,10 @@
 @use '@sass/mosaicVariables' as *;
 
 .navigation {
+  box-sizing: border-box;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  & .MuiTabs-indicator {
-    background-color: $mosaic-purple-dark;
-  }
-  & .MuiTab-textColorPrimary {
-    color: $mosaic-purple-dark;
-  }
-  & .MuiTab-textColorPrimary.Mui-selected {
-    color: $mosaic-purple-dark;
-  }
+  justify-content: space-between;
+  z-index: 10;
+  gap: $spacing-space-12;
+  padding: 0 10px 0 10px;
 }

--- a/mosaic-frontend/src/components/Navigation/navigationButton.scss
+++ b/mosaic-frontend/src/components/Navigation/navigationButton.scss
@@ -1,30 +1,36 @@
-@use '@sass/mosaicVariables.scss' as *;
-@use '@sass/mosaicMixins.scss' as *;
+@use '@sass/mosaicVariables' as *;
+@use '@sass/mosaicMixins' as *;
 
-
-.promptButton {
-  width: 140px;
-  height: $size-bttn-small;
-  background: $button-color-default;
-  color: $button-background-default; 
+.navigationButton {  
   box-sizing: border-box;
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: $spacing-space-16;
-  text-wrap: nowrap;
+  border: none;
   cursor: pointer;
+  color: $button-background-default; 
+  @include dropShadow-0-5();
   border-radius: $button-border-radius;
   border: $button-border-light;
-  @include dropShadow-0-5();
+  background: $button-color-default;
+  width: 100%;
+  min-height: 60px;
   @include font-style($size: 18px, $weight: 500, $transform: uppercase, $lineHeight: 0.5);
+
 
   &:hover {
     color: $button-background-hover;
     background: $button-background-default;
   }
+
   &:active {
     color: $button-background-pressed;
+    @include dropShadow-2();
+  }
+  
+  &--selected {
+    color: $button-background-hover;
+    background: $button-background-default;
     @include dropShadow-2();
   }
 }

--- a/mosaic-frontend/src/components/ScrubberSlider/ScrubberSlider.tsx
+++ b/mosaic-frontend/src/components/ScrubberSlider/ScrubberSlider.tsx
@@ -15,6 +15,7 @@ const ScrubberSlider: React.FC<ScrubberSliderProps> = ({ width }) => {
   const { currentScrubberFrame, scrubberFramesMax } = useSelector<RootState, ScrubberState>(
     (state) => state.scrubber
   );
+  const trackWidth = width - 60;
 
   const handleChange = (_: any, newValue: number | number[]) => {
   traceEvent({
@@ -30,7 +31,7 @@ const ScrubberSlider: React.FC<ScrubberSliderProps> = ({ width }) => {
   }
 
   return (
-    <div style={{ width }}>
+    <div style={{ width: trackWidth }}>
       <div className='scrubberSlider'>
         <Slider
           value={currentScrubberFrame}

--- a/mosaic-frontend/src/components/ScrubberSlider/scrubberSlider.scss
+++ b/mosaic-frontend/src/components/ScrubberSlider/scrubberSlider.scss
@@ -1,4 +1,5 @@
 @use '@sass/mosaicVariables' as *;
+@use '@sass/mosaicMixins' as *;
 
 .scrubberSlider {
   display: flex;
@@ -9,16 +10,25 @@
   &__slider {
     width: 90%;
     & .MuiSlider-thumb {
-      width: 24px;
-      height: 24px;
-      margin-top: -12px;
-      margin-left: -12px;
+      width: 36px;
+      height: 36px;
+      margin-top: -18px;
+      margin-left: -18px;
       background-color: $mosaic-purple-dark;
     }
     & .MuiSlider-valueLabel {
-      left: calc(-50% + 8px);
-      top: -30px;
+      left: calc(-2%);
+      top: -34px;
+      .PrivateValueLabel-circle-4 {
+        background-color: $button-color-default;
+        border: 2px solid $mosaic-purple-dark;
+        .PrivateValueLabel-label-5 {
+          color: $mosaic-purple-dark;
+          @include font-style($size: 18px, $weight: 500, $transform: uppercase, $lineHeight: 0.5);
+        }
+      }
       color: $mosaic-purple-dark;
+      
     }
   }
 }

--- a/mosaic-frontend/src/typescript/interfaces/NavigationButtonProps.ts
+++ b/mosaic-frontend/src/typescript/interfaces/NavigationButtonProps.ts
@@ -1,0 +1,8 @@
+import { NavPhaseEnum } from '@enums/NavPhaseEnum';
+
+export type NavigationButtonProps = {
+  label: string;
+  value: NavPhaseEnum;
+  activeNavPhase: NavPhaseEnum;
+  onClick: (navPhase: NavPhaseEnum) => void;
+}


### PR DESCRIPTION


## Description

Fixes # MOS-131.replace.mui.nav.buttons
- Upload/Edit/Save mui navigation buttons replaced with SASS
- Increase size of slider thumb

BEFORE
![Screenshot 2025-01-28 132718](https://github.com/user-attachments/assets/100e928d-75dd-411f-8496-7ff552841d9c)


AFTER

![Screenshot 2025-01-28 180555](https://github.com/user-attachments/assets/ca068b38-2277-439b-8073-086b0818c1a9)

