### PR TITLE
MOS-147 FFmpeg socket updates added to all encoding stages

### DIFF
--- a/mosaic-frontend/src/components/FileIOPrompt/FileIOPrompt.tsx
+++ b/mosaic-frontend/src/components/FileIOPrompt/FileIOPrompt.tsx
@@ -8,7 +8,7 @@ import './fileIOPrompt.scss';
 let socket: Socket;
 
 const FileIOPrompt = ({ action, videoDuration = 0, callBack = () => {}, onCancel = () => {} }: FileIOPromptProps) => {
-  const [progressFrames, setProgressFrames] = useState({currentFrame: 0, totalFrames: 0});
+  const [progressFrames, setProgressFrames] = useState({actionName: 'Reading', currentFrame: 0, totalFrames: 0});
   const { headline, headlineIcon, message, buttonLabel } = PROMPT[action];
   const formattedMessage = action === 'videoTooLong' 
   ? message.replace('VIDEO_DURATION', Number(videoDuration).toFixed(2)) 
@@ -17,8 +17,9 @@ const FileIOPrompt = ({ action, videoDuration = 0, callBack = () => {}, onCancel
 
   useEffect(() => {
     socket = io();
-    socket.on('ffmpegProgress', (data: { currentFrame: number, totalFrames: number }) => {
-          setProgressFrames({currentFrame: data.currentFrame, totalFrames: data.totalFrames});
+    socket.on('ffmpegProgress', 
+      (data: { actionName: string, currentFrame: number, totalFrames: number }) => {
+          setProgressFrames({actionName: data.actionName, currentFrame: data.currentFrame, totalFrames: data.totalFrames});
         }
     );
   }, []);
@@ -31,7 +32,7 @@ const FileIOPrompt = ({ action, videoDuration = 0, callBack = () => {}, onCancel
       <div>
         {!showButtons && 
           <p className='fileIOPrompt__progressMessage'>
-            Processing frame <span style={{ display: "inline-block", width: "4ch", textAlign: "right" }}>{progressFrames.currentFrame}</span> of {progressFrames.totalFrames}
+            {progressFrames.actionName} frame <span style={{ display: "inline-block", width: "3ch", textAlign: "right" }}>{progressFrames.currentFrame}</span> of {progressFrames.totalFrames}
           </p>
         }
         {formattedMessage}


### PR DESCRIPTION
## Description
To address issue with status update holding on 'Processing frame 0 of 0' for 3 seconds before updating, socket update emit message has been added to all four FFmpeg encoding methods:
- cropVideo
- resizeVideo
- exportFrames
- renderMosaic

NOTE: Previously, only cropVideo and renderMosaic emitted updates.

Fixes # MOS-147 Encoding status hanging on zero

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested in local dev environment

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
