### PR TITLE
Fix backend crash on Docker: Node 10 runtime and Environment import casing

### DIFF
--- a/mosaic-backend/Dockerfile
+++ b/mosaic-backend/Dockerfile
@@ -1,5 +1,5 @@
 #build stage for a Node.js application
-FROM node:10-alpine AS build-stage
+FROM node:20-alpine AS build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
@@ -7,7 +7,7 @@ COPY . ./
 RUN npm run build
 
 #production stage
-FROM node:10-alpine AS production-stage
+FROM node:20-alpine AS production-stage
 WORKDIR /app
 COPY --from=build-stage /app /app
 EXPOSE 3001

--- a/mosaic-backend/lib/App.ts
+++ b/mosaic-backend/lib/App.ts
@@ -4,7 +4,7 @@ import { MosaicRoutes } from "./MosaicRoutes";
 const expressFileUpload = require('express-fileupload');
 import { Server } from 'socket.io';
 import { createServer } from 'http';
-import env from './Environment';
+import env from './environment';
 
 const app = express();
 app.use(bodyParser.urlencoded({ extended: false }));

--- a/mosaic-backend/lib/MosaicRoutes.ts
+++ b/mosaic-backend/lib/MosaicRoutes.ts
@@ -1,6 +1,6 @@
 import { Application, Request, Response } from 'express';
 import { MosaicController } from './MosaicController';
-import env from './Environment';
+import env from './environment';
 
 
 export class MosaicRoutes {

--- a/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
@@ -3,7 +3,7 @@ import ffmpeg from '@ffmpeg-installer/ffmpeg';
 import ffprobe from 'ffprobe';
 import ffprobeStatic from 'ffprobe-static';
 import { createFfmpegFilterComplexStr } from './utils/createFfmpegFilterComplexStr';
-import env from '../../Environment';
+import env from '../../environment';
 import { Request, Response } from 'express';
 import { io } from '../../App';
 

--- a/mosaic-backend/lib/MosaicServices/FileService/FileService.ts
+++ b/mosaic-backend/lib/MosaicServices/FileService/FileService.ts
@@ -1,4 +1,4 @@
-import env from '../../Environment';
+import env from '../../environment';
 import { Request, Response } from 'express';
 const fs = require('fs');
 

--- a/mosaic-backend/package.json
+++ b/mosaic-backend/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "Express.js server for the 'mosaic' web app",
   "main": "./dist/server.js",
-  "type": "module",
   "scripts": {
     "start": "npm run build:live",
     "build": "tsc -p .",


### PR DESCRIPTION
## Summary
- Bump `mosaic-backend/Dockerfile` from `node:10-alpine` to `node:20-alpine`. socket.io v4 calls `Object.fromEntries` (Node 12+), so the backend crashed on its first socket connection under Node 10 — with no restart policy, this killed the whole container and left every upload/render request hanging indefinitely (reproduced via `docker compose -f docker-compose-dev.yaml up`).
- Remove stray `"type": "module"` from `mosaic-backend/package.json`. The TS build emits CommonJS (`tsconfig.json` → `module: commonjs`), which conflicted with Node 20's stricter ESM/CJS enforcement and crashed `dist/server.js` on boot after the Node bump.
- Fix four imports referencing `./Environment` / `../../Environment` (capital E) to match the actual file `lib/environment.ts`. This only resolved on case-insensitive filesystems (Windows/macOS) and failed the TypeScript build inside the Linux-based Docker image.

## Test plan
- [x] `docker compose -f docker-compose-dev.yaml up -d --build` builds all three images and starts all three containers without errors
- [x] Backend logs show only `Express server listening on port 3001`, no crash
- [x] `http://localhost/` loads the app (HTTP 200) through the nginx proxy
- [x] Socket.io handshake (`/socket.io/?EIO=4&transport=polling`) returns HTTP 200 and backend stays up afterward
- [x] End-to-end video upload/edit/render flow verified working in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)