### PR TITLE
Add automated EC2 deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,102 @@
+name: Deploy to EC2
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to build and deploy (defaults to the commit SHA)'
+        required: false
+        type: string
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: tag
+        run: echo "image_tag=${{ inputs.image_tag || github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mosaic-backend
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/mosaic-backend:${{ steps.tag.outputs.image_tag }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/mosaic-backend:latest
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mosaic-frontend
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/mosaic-frontend:${{ steps.tag.outputs.image_tag }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/mosaic-frontend:latest
+
+      - name: Build and push proxy image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mosaic-proxy
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/mosaic-proxy:${{ steps.tag.outputs.image_tag }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/mosaic-proxy:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to EC2
+        env:
+          SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+          EC2_USER: ${{ secrets.EC2_USER }}
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p ~/.ssh
+          umask 077
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/deploy_key"
+
+          ssh $SSH_OPTS "$EC2_USER@$EC2_HOST" "mkdir -p ~/mosaic-app/assets"
+          scp $SSH_OPTS docker-compose.yaml "$EC2_USER@$EC2_HOST:~/mosaic-app/docker-compose.yaml"
+          scp $SSH_OPTS -r assets/330055 "$EC2_USER@$EC2_HOST:~/mosaic-app/assets/"
+          scp $SSH_OPTS assets/favicon-16x16.png "$EC2_USER@$EC2_HOST:~/mosaic-app/assets/favicon-16x16.png"
+
+          ssh $SSH_OPTS "$EC2_USER@$EC2_HOST" "
+            cd ~/mosaic-app &&
+            echo IMAGE_TAG=$IMAGE_TAG > .env &&
+            docker compose pull &&
+            docker compose up -d --remove-orphans &&
+            docker image prune -af
+          "

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,31 @@
+services:
+
+  proxy:
+    depends_on:
+      - frontend
+    image: patricksyoung/mosaic-proxy:${IMAGE_TAG:-latest}
+    ports:
+      - '80:80'
+    networks:
+      - mosaic-network
+
+  frontend:
+    image: patricksyoung/mosaic-frontend:${IMAGE_TAG:-latest}
+    networks:
+      - mosaic-network
+
+  backend:
+    image: patricksyoung/mosaic-backend:${IMAGE_TAG:-latest}
+    volumes:
+      - mosaic-volume:/var/lib/video
+      - ./assets/330055:/var/lib/video/330055
+      - ./assets/favicon-16x16.png:/var/lib/favicon-16x16.png
+    networks:
+      - mosaic-network
+
+volumes:
+  mosaic-volume:
+
+networks:
+  mosaic-network:
+    driver: bridge # a user defined bridge is required; the default bridge network doesn't support name resolution


### PR DESCRIPTION
## Summary
- Recreates the root `docker-compose.yaml` (deleted from the repo a while back), matching what's actually running in production today, but parameterized with `${IMAGE_TAG}` instead of hardcoded per-service version numbers.
- Adds `.github/workflows/deploy.yaml`: a manually-triggered (`workflow_dispatch`) GitHub Actions workflow that:
  1. Builds and pushes all three images (`mosaic-backend`, `mosaic-frontend`, `mosaic-proxy`) to Docker Hub, tagged with the commit SHA and `latest`.
  2. Copies `docker-compose.yaml` and the default demo assets (`assets/330055`, `assets/favicon-16x16.png`) to the EC2 host.
  3. Runs `docker compose pull && docker compose up -d --remove-orphans` in a single persistent `~/mosaic-app` directory on the server, then prunes old images.

This replaces the previous fully-manual process (hand-build images locally, push to Docker Hub, SSH in, create a new dated folder, copy assets, `docker compose up`) with a one-click GitHub Actions run.

Deploy stays manual-trigger-only by design — there's no staging environment for this app, so auto-deploy-on-merge felt too risky.

## Secrets configured on the repo
- `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` — Docker Hub access token (read & write)
- `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY` — SSH access to the production instance

## Test plan
- [ ] Merge to main, then manually dispatch the workflow and confirm it builds, pushes, and deploys successfully
- [ ] Verify http://mosaic.mobi (or the EC2 host) still serves the app after the run
- [ ] Confirm old containers are cleanly replaced with no orphaned resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)