### PR TITLE
Fix deploy workflow: use docker-compose binary, not docker compose plugin

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -96,7 +96,7 @@ jobs:
           ssh $SSH_OPTS "$EC2_USER@$EC2_HOST" "
             cd ~/mosaic-app &&
             echo IMAGE_TAG=$IMAGE_TAG > .env &&
-            docker compose pull &&
-            docker compose up -d --remove-orphans &&
+            docker-compose pull &&
+            docker-compose up -d --remove-orphans &&
             docker image prune -af
           "


### PR DESCRIPTION
## Summary
First live test run of the new deploy workflow (run 28749344363) confirmed image builds, pushes, SSH connection, and file transfer all worked — but the final deploy command failed:
\`\`\`
docker: 'compose' is not a docker command.
\`\`\`
The EC2 host has the standalone `docker-compose` v2 binary at `/usr/local/bin/docker-compose` but not the `docker compose` CLI plugin. Switched both commands to the hyphenated binary that's actually installed there.

No impact to the live app — the failure happened before touching any running container; verified via SSH that all three original production containers were still up afterward.

## Test plan
- [ ] Merge and re-run the workflow, confirm `docker-compose pull`/`up -d` succeeds and the app is reachable afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)