### PR TITLE
Speed up video crop step with ultrafast preset

### DIFF
--- a/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
@@ -46,7 +46,7 @@ export default class FFmpegService {
       y: yOffset
     }
     const filter = `[0:v] crop=${crop.w}:${crop.h}:${crop.x}:${crop.y}, scale=${1080}:-1 [final]`;
-    const proc = spawn(ffmpeg.path, ['-i', inputPath, '-filter_complex', filter , '-map', '[final]', '-an', '-y', outputPath]);
+    const proc = spawn(ffmpeg.path, ['-i', inputPath, '-filter_complex', filter , '-preset', 'ultrafast', '-crf', '28', '-map', '[final]', '-an', '-y', outputPath]);
       // @ts-ignore: Object is possibly 'null'.
     proc.stdout.on('data', function(data) {
       console.log(`cropVideo > proc.stdout.on('data'): ${data}`);


### PR DESCRIPTION
## Summary
Investigated whether moving ffmpeg processing to Lambda would speed up video-related actions. Before considering that architectural change, benchmarked the actual ffmpeg steps directly on the production EC2 instance (`t3.small`, 2 vCPU, burstable) to find the real bottleneck.

`cropVideo` was the only step in the upload pipeline (`probeVideo` → `cropVideo` → `resizeVideo` → `exportFrames`) missing `-preset ultrafast -crf 28`, which `resizeVideo` and `exportFrames` both already use. That single missing flag made crop dramatically slower than it needs to be:

| | Before | After |
|---|---|---|
| Wall time | 8.47s | 1.72s |
| CPU-seconds (both cores) | 15.93s | 3.33s |

(Measured with a real ~4.6s test clip, run directly inside the production backend container's ephemeral `/tmp`, not touching the production video volume.)

This cuts total upload-processing time (crop+resize+exportFrames) from ~10.15s to ~3.4s, and — probably more importantly for this `t3.small` — cuts CPU credit consumption for the step that was pinning both vCPUs near 100% for 8+ seconds per upload. No architecture change needed; Lambda migration would have added S3-based storage, ffmpeg-as-a-layer packaging, and cold-start/round-trip latency across several chained steps for a smaller win than this.

## Test plan
- [x] Re-ran crop with the added flags directly on production against the real demo asset's `upload.mov`, confirmed output is valid and ~5x faster
- [ ] After merge, trigger a real upload through the app and confirm cropped/resized/exported output still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)