### PR TITLE
Speed up render, fix progress frame count, harden download filename

### DIFF
--- a/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
@@ -129,34 +129,40 @@ export default class FFmpegService {
     const frameInterval = duration / 18;
     const bgFrameStart = (res.locals.currentScrubberFrame - 1) * frameInterval;
     const inputDuration = res.locals.videoUpload.duration;
+    const outputFps = 25;
     const filterParams = {
       panelCount: res.locals.numTiles,
       sequenceCount: res.locals.numTiles > 4 ? 3 : 4,
       fadeInToOutDuration: 2.0,
       outputDuration: 15.0,
+      outputFps,
       outputSize: '1080x1080',
       bgFrameHue: 'hue=s=0.1',
       preCropStr: '',
       inputDuration
     }
+    // the rendered output always has a fixed duration/frame rate regardless of
+    // the source clip's length, so progress must be tracked against the
+    // output's own frame count rather than the uploaded video's totalFrames
+    const totalOutputFrames = filterParams.outputDuration * filterParams.outputFps;
     const assetID = res.locals.assetID
-    const inputPath  = `${env.getVolumnPath()}/${assetID}/cropped.mov`; 
+    const inputPath  = `${env.getVolumnPath()}/${assetID}/cropped.mov`;
     const bgImagePath = `${env.getVolumnPath()}/${assetID}/${res.locals.currentScrubberFrame}`;
-    const outputDirectory = `${env.getVolumnPath()}/${assetID}`; 
-    const outputPath = `${outputDirectory}/mosaic.mov`; 
+    const outputDirectory = `${env.getVolumnPath()}/${assetID}`;
+    const outputPath = `${outputDirectory}/mosaic.mov`;
     const ffmpegFilterComplexStr = createFfmpegFilterComplexStr(filterParams);
-    const proc = spawn(ffmpeg.path, ['-i', bgImagePath, '-i', inputPath, '-filter_complex', ffmpegFilterComplexStr, '-preset', 'fast', '-crf', '26', '-map', '[final]', '-an', '-y', outputPath]);
+    const proc = spawn(ffmpeg.path, ['-i', bgImagePath, '-i', inputPath, '-filter_complex', ffmpegFilterComplexStr, '-preset', 'veryfast', '-crf', '26', '-map', '[final]', '-an', '-y', outputPath]);
     // @ts-ignore: Object is possibly 'null'.
     proc.stdout.on('data', function(data) {
       console.log(`proc.stdout.on('data'): ${data}`);
-    });   
+    });
     // @ts-ignore: Object is possibly 'null'.
     proc.stderr.setEncoding("utf8")
     // @ts-ignore: Object is possibly 'null'.
     proc.stderr.on('data', function(data) {
       const lines = data.split(/\s+/);
       if (lines[0] === 'frame=') {
-        io.emit('ffmpegProgress', { actionName: 'Rendering', currentFrame: lines[1], totalFrames: res.locals.videoUpload.totalFrames });
+        io.emit('ffmpegProgress', { actionName: 'Rendering', currentFrame: lines[1], totalFrames: totalOutputFrames });
       }
     });
     proc.on('close', function() {

--- a/mosaic-backend/lib/MosaicServices/FFmpegService/utils/createFfmpegFilterComplexStr.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/utils/createFfmpegFilterComplexStr.ts
@@ -9,6 +9,7 @@ export const createFfmpegFilterComplexStr =  ({
   fadeInToOutDuration,
   inputDuration,
   outputDuration,
+  outputFps,
   outputSize,
   bgFrameHue,
   preCropStr
@@ -18,7 +19,7 @@ export const createFfmpegFilterComplexStr =  ({
 
   /////////////////////////////
   // CREATE BASE AND BG
-  ffmpegFilterComplexStr += `nullsrc=size=${outputSize}:duration=${outputDuration} [base];\n`;
+  ffmpegFilterComplexStr += `nullsrc=size=${outputSize}:duration=${outputDuration}:rate=${outputFps} [base];\n`;
   //ffmpegFilterComplexStr += `[0:v] ${preCropStr}trim=start=${bgFrameStart}:duration=0.05, setpts=PTS-STARTPTS${bgFrameHue} [bg_frame];\n`;
   ffmpegFilterComplexStr += `[0:v]${bgFrameHue}[bg_frame];\n`;
   ffmpegFilterComplexStr += `[base][bg_frame] overlay [bg];\n`;

--- a/mosaic-frontend/src/components/RenderMosaic/RenderMosaic.tsx
+++ b/mosaic-frontend/src/components/RenderMosaic/RenderMosaic.tsx
@@ -47,7 +47,7 @@ const RenderMosaic: React.FC<RenderMosaicProps> = ({ displaySize, isActive }) =>
         action: 'onSaveVideo',
         label: 'N/A'
       });
-      FileDownload(renderBlob, downloadFileName);
+      FileDownload(renderBlob, downloadFileName, 'video/quicktime');
       dispatch(setRenderPhase({ renderPhase: RenderPhaseEnum.RENDER_PROMPT }));
       dispatch(setNavPhase({navPhase: NavPhaseEnum.EDIT}));  
       dispatch(setAppPhase({ appPhase: AppPhaseEnum.NOT_LOADING}));

--- a/mosaic-frontend/src/components/UploadVideo/upload.slice.ts
+++ b/mosaic-frontend/src/components/UploadVideo/upload.slice.ts
@@ -52,7 +52,8 @@ const uploadSlice = createSlice ({
         state.uploadPhase = UploadPhaseEnum.VIDEO_TOO_LONG;
       } else {
         state.selectedFile = action.payload.selectedFile;
-        state.downloadFileName = action.payload.selectedFile.name.replace(regex, '_mosaic.mov');
+        const baseFileName = action.payload.selectedFile.name.replace(regex, '') || 'video';
+        state.downloadFileName = `${baseFileName}_mosaic.mov`;
         state.uploadPhase = UploadPhaseEnum.VIDEO_SUBMITED;
       }
     }) 


### PR DESCRIPTION
## Summary
Investigated all three issues reported after the crop speedup, benchmarking directly against the production EC2 instance using the app's actual filter graph (via `-filter_complex_script` to avoid shell-quoting issues).

**1. Render speed.** `renderMosaic` used `-preset fast -crf 26`. Tested several presets at the same crf (holding quality target constant):

| Preset | crf | Wall time | Output size |
|---|---|---|---|
| fast (current) | 26 | 8.77s | 478KB |
| **veryfast (new)** | 26 | **4.96s** | **378KB** |
| faster | 26 | 7.88s | 467KB |
| superfast | 26 | 4.35s | 608KB |
| ultrafast | 28 | 3.75s | 1092KB |

`veryfast` is the clear win — ~43% faster **and** a smaller file than what's running today. `ultrafast` was tempting (matches the earlier crop fix) but produces a noticeably larger/lower-quality output, an unacceptable tradeoff for a *final delivered* video (unlike crop's output, which is just an intermediate file re-encoded again downstream).

**2. Progress showing frame counts past the total.** `renderMosaic`'s progress emit used `res.locals.videoUpload.totalFrames` — the *original uploaded clip's* frame count — as the denominator. But the render always outputs a fixed 15-second clip regardless of input length (confirmed via ffprobe on a real production render: `nb_frames=375` at `25fps` for a source clip with far fewer frames). Made the output fps explicit (`nullsrc` now sets `:rate=25` instead of relying on ffmpeg's implicit default) and compute the progress denominator from the render's own `outputDuration * outputFps`.

**3. Downloaded file not playing.** Verified the backend output itself is valid (`ffprobe probe_score=100`, standard h264/mov, plays fine) — not content corruption. Found the actual bug in the frontend filename logic: `selectedFile.name.replace(regex, '_mosaic.mov')` silently no-ops when the original filename has no extension (a non-matching `.replace()` just returns the string unchanged), leaving the downloaded file with **no extension at all**. Fixed to always strip any existing extension and append `_mosaic.mov` unconditionally. Also passed an explicit `video/quicktime` MIME type to the download call instead of the default generic `application/octet-stream`.

## Test plan
- [x] Backend and frontend both type-check cleanly (`tsc --noEmit`)
- [x] Benchmarked render presets directly against production, verified `veryfast` output is valid via ffprobe
- [x] Confirmed `totalOutputFrames` (15.0 × 25 = 375) matches the real render's `nb_frames` exactly
- [ ] After merge/deploy, do a real render through the UI and confirm progress no longer overshoots and the downloaded file opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)