### PR TITLE
Shorten downloaded filename to an upload timestamp

### DIFF
--- a/mosaic-frontend/src/components/UploadVideo/upload.slice.ts
+++ b/mosaic-frontend/src/components/UploadVideo/upload.slice.ts
@@ -46,17 +46,18 @@ const uploadSlice = createSlice ({
       console.log(`preUploadValidation.pending > action.payload: ${action.payload}`);
     })
     builder.addCase(preUploadValidation.fulfilled, (state, action) => {
-      const regex = new RegExp(/\.[^/.]+$/); 
       state.uploadDuration = action.payload.uploadDuration;
       if (state.uploadDuration > MAX_VIDEO_UPLOAD_DURATION) {
         state.uploadPhase = UploadPhaseEnum.VIDEO_TOO_LONG;
       } else {
         state.selectedFile = action.payload.selectedFile;
-        const baseFileName = action.payload.selectedFile.name.replace(regex, '') || 'video';
-        state.downloadFileName = `${baseFileName}_mosaic.mov`;
+        const now = new Date();
+        const pad = (n: number) => String(n).padStart(2, '0');
+        const timestamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+        state.downloadFileName = `mosaic_${timestamp}.mov`;
         state.uploadPhase = UploadPhaseEnum.VIDEO_SUBMITED;
       }
-    }) 
+    })
     // Step 2: upload user video
     builder.addCase(uploadUserVideo.rejected, (_, action) => {
       console.warn(`uploadUserVideo.rejected > action.payload: ${action.payload}`);


### PR DESCRIPTION
## Summary
Requested follow-up to the download-filename fix in #53: use a short timestamp-based name instead of one derived from the original uploaded file's name.

`downloadFileName` is now generated from the time of upload as `mosaic_YYYYMMDD_HHmmss.mov` (e.g. `mosaic_20260705_184712.mov`), independent of whatever the source file was named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)