### PR TITLE
Add S3 archival and password-protected admin report page

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -78,6 +78,9 @@ jobs:
           EC2_HOST: ${{ secrets.EC2_HOST }}
           EC2_USER: ${{ secrets.EC2_USER }}
           IMAGE_TAG: ${{ needs.build-and-push.outputs.image_tag }}
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
         run: |
           set -euo pipefail
 
@@ -95,7 +98,8 @@ jobs:
 
           ssh $SSH_OPTS "$EC2_USER@$EC2_HOST" "
             cd ~/mosaic-app &&
-            echo IMAGE_TAG=$IMAGE_TAG > .env &&
+            printf 'IMAGE_TAG=%s\nS3_BUCKET_NAME=%s\nAWS_REGION=%s\nADMIN_PASSWORD=%s\n' \
+              '$IMAGE_TAG' '$S3_BUCKET_NAME' '$AWS_REGION' '$ADMIN_PASSWORD' > .env &&
             docker-compose pull &&
             docker-compose up -d --remove-orphans &&
             docker image prune -af

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -23,6 +23,10 @@ services:
     build:
       context: ./mosaic-backend
       dockerfile: Dockerfile
+    environment:
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME:-}
+      - AWS_REGION=${AWS_REGION:-us-west-1}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
     volumes:
       - mosaic-volume:/var/lib/video
       - ./assets/330055:/var/lib/video/330055

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,10 @@ services:
 
   backend:
     image: patricksyoung/mosaic-backend:${IMAGE_TAG:-latest}
+    environment:
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME:-}
+      - AWS_REGION=${AWS_REGION:-us-west-1}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
     volumes:
       - mosaic-volume:/var/lib/video
       - ./assets/330055:/var/lib/video/330055

--- a/mosaic-backend/lib/AdminRoutes.ts
+++ b/mosaic-backend/lib/AdminRoutes.ts
@@ -1,0 +1,47 @@
+import { Application, Request, Response } from 'express';
+import basicAuth from 'express-basic-auth';
+import S3Service from './MosaicServices/S3Service/S3Service';
+import env from './environment';
+const path = require('path');
+
+export class AdminRoutes {
+  private s3Service: S3Service = new S3Service();
+
+  public route(app: Application) {
+    const auth = basicAuth({
+      users: { admin: env.getAdminPassword() },
+      challenge: true,
+      unauthorizedResponse: 'Unauthorized'
+    });
+
+    app.get('/admin', auth, (req: Request, res: Response) => {
+      res.sendFile(path.join(__dirname, '../public/admin/index.html'));
+    });
+
+    app.get('/admin/api/assets', auth, async (req: Request, res: Response) => {
+      try {
+        const assetIDs = await this.s3Service.listAssetIDs();
+        const assets = await Promise.all(assetIDs.map(async (assetID) => {
+          const manifest = await this.s3Service.getManifest(assetID);
+          return manifest ? { assetID, ...manifest } : null;
+        }));
+        const found = assets.filter((asset) => asset !== null);
+        found.sort((a: any, b: any) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime());
+        res.json({ assets: found });
+      } catch (err) {
+        res.status(500).json({ error: true, message: String(err) });
+      }
+    });
+
+    app.get('/admin/api/video-url', auth, async (req: Request, res: Response) => {
+      const assetID = String(req.query.assetID ?? '');
+      const filename = String(req.query.filename ?? '');
+      const url = await this.s3Service.getSignedVideoUrl(assetID, filename);
+      if (!url) {
+        res.status(404).json({ error: true, message: 'Not found' });
+        return;
+      }
+      res.json({ url });
+    });
+  }
+}

--- a/mosaic-backend/lib/App.ts
+++ b/mosaic-backend/lib/App.ts
@@ -1,15 +1,21 @@
 const express = require('express');
 import * as bodyParser from "body-parser";
 import { MosaicRoutes } from "./MosaicRoutes";
+import { AdminRoutes } from "./AdminRoutes";
 const expressFileUpload = require('express-fileupload');
 import { Server } from 'socket.io';
 import { createServer } from 'http';
 import env from './environment';
 
 const app = express();
+app.set('trust proxy', true);
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(expressFileUpload());
 app.use('/uploads', express.static(`${env.getVolumnPath()}`));
+// admin routes must be registered before MosaicRoutes, which ends in a
+// catch-all 404 handler that would otherwise swallow every other route
+const adminRoutes = new AdminRoutes();
+adminRoutes.route(app);
 const mosaicRoutes = new MosaicRoutes();
 mosaicRoutes.route(app);
 

--- a/mosaic-backend/lib/MosaicController.ts
+++ b/mosaic-backend/lib/MosaicController.ts
@@ -1,13 +1,39 @@
 import { Request, Response } from 'express';
 import FileService from './MosaicServices/FileService/FileService';
 import FFmpegService from './MosaicServices/FFmpegService/FFmpegService';
+import ManifestService from './MosaicServices/ManifestService/ManifestService';
+import S3Service from './MosaicServices/S3Service/S3Service';
+import env from './environment';
 
 export class MosaicController {
   private fileService: FileService = new FileService();
   private ffmpegService: FFmpegService = new FFmpegService();
+  private manifestService: ManifestService = new ManifestService();
+  private s3Service: S3Service = new S3Service();
 
   public uploadVideo (req: Request, res: Response, next: any) {
     this.fileService.uploadVideo(req, res, next);
+  }
+
+  public createManifest (req: Request, res: Response, next: any) {
+    this.manifestService.createManifest(req, res, next);
+  }
+
+  public recordRender (req: Request, res: Response, next: any) {
+    const assetID = String(req.query.assetID);
+    this.manifestService.recordRender(
+      assetID,
+      Number(req.query.numTiles),
+      String(req.query.currentScrubberFrame)
+    );
+    next();
+
+    // archive right away so the report reflects recent activity without
+    // waiting for the periodic sweep; local copy is left in place so the
+    // user can keep re-rendering this asset in the same session
+    const assetDir = `${env.getVolumnPath()}/${assetID}`;
+    this.s3Service.uploadAsset(assetID, assetDir, ['upload.mov', 'mosaic.mov', 'manifest.json'])
+      .catch((err) => console.log(`recordRender S3 archive err: ${err}`));
   }
 
   public probeVideo (req: Request, res: Response, next: any) {

--- a/mosaic-backend/lib/MosaicRoutes.ts
+++ b/mosaic-backend/lib/MosaicRoutes.ts
@@ -7,8 +7,9 @@ export class MosaicRoutes {
   private mosaicController: MosaicController = new MosaicController();
 
   public route(app: Application) {
-    app.post('/uploadvideo',  
-      (req, res, next) => this.mosaicController.uploadVideo(req, res, next), 
+    app.post('/uploadvideo',
+      (req, res, next) => this.mosaicController.uploadVideo(req, res, next),
+      (req, res, next) => this.mosaicController.createManifest(req, res, next),
       (req, res, next) => this.mosaicController.probeVideo(req, res, next),
       (req, res, next) => this.mosaicController.cropVideo(req, res, next),
       (req, res, next) => this.mosaicController.resizeVideo(req, res, next),
@@ -16,12 +17,13 @@ export class MosaicRoutes {
       (req, res, next) => res.status(200).json({assetID: res.locals.assetID})
      );
 
-    app.get('/render/mosaic',  
+    app.get('/render/mosaic',
       (req, res, next) => {
         res.locals = { ...res.locals, ...req.query }
         this.mosaicController.probeVideo(req, res, next)
       },
-      (req, res, next) => this.mosaicController.renderMosaic(req, res, next), 
+      (req, res, next) => this.mosaicController.renderMosaic(req, res, next),
+      (req, res, next) => this.mosaicController.recordRender(req, res, next),
       (req, res, next) => res.download(`${env.getVolumnPath()}/${req.query.assetID}/mosaic.mov`)
     );
      

--- a/mosaic-backend/lib/MosaicServices/ArchiveService/ArchiveService.ts
+++ b/mosaic-backend/lib/MosaicServices/ArchiveService/ArchiveService.ts
@@ -1,0 +1,55 @@
+import env from '../../environment';
+import S3Service from '../S3Service/S3Service';
+const fs = require('fs');
+
+const ASSET_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour of inactivity before archiving
+// the bundled demo asset the frontend always references by default; never archive/delete it
+const EXCLUDED_ASSET_IDS = ['330055'];
+
+export default class ArchiveService {
+  private s3Service: S3Service = new S3Service();
+
+  public async sweep(): Promise<void> {
+    const volumePath = env.getVolumnPath();
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(volumePath);
+    } catch (err) {
+      console.log(`ArchiveService.sweep readdir err: ${err}`);
+      return;
+    }
+
+    for (const assetID of entries) {
+      if (EXCLUDED_ASSET_IDS.includes(assetID)) continue;
+      const assetDir = `${volumePath}/${assetID}`;
+
+      let stats;
+      try {
+        stats = fs.statSync(assetDir);
+      } catch (err) {
+        continue;
+      }
+      if (!stats.isDirectory()) continue;
+
+      const age = Date.now() - this.getLastActivityTime(assetDir);
+      if (age < ASSET_MAX_AGE_MS) continue;
+
+      try {
+        await this.s3Service.uploadAsset(assetID, assetDir, ['upload.mov', 'mosaic.mov', 'manifest.json']);
+        fs.rmSync(assetDir, { recursive: true, force: true });
+        console.log(`ArchiveService.sweep archived and removed asset ${assetID}`);
+      } catch (err) {
+        // leave the local copy in place if the upload failed (e.g. S3 not configured yet)
+        console.log(`ArchiveService.sweep err for asset ${assetID}: ${err}`);
+      }
+    }
+  }
+
+  private getLastActivityTime(assetDir: string): number {
+    try {
+      return fs.statSync(`${assetDir}/manifest.json`).mtimeMs;
+    } catch (err) {
+      return fs.statSync(assetDir).mtimeMs;
+    }
+  }
+}

--- a/mosaic-backend/lib/MosaicServices/GeoService/GeoService.ts
+++ b/mosaic-backend/lib/MosaicServices/GeoService/GeoService.ts
@@ -1,0 +1,36 @@
+import axios from 'axios';
+
+export interface GeoLocation {
+  country: string | null;
+  region: string | null;
+  city: string | null;
+}
+
+export default class GeoService {
+  public async lookupLocation(ip: string): Promise<GeoLocation> {
+    const empty: GeoLocation = { country: null, region: null, city: null };
+
+    // private/loopback addresses (local dev, internal health checks) aren't geolocatable
+    if (!ip || ip === '::1' || ip === '127.0.0.1' || /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(ip)) {
+      return empty;
+    }
+
+    try {
+      const response = await axios.get(`http://ip-api.com/json/${ip}`, {
+        params: { fields: 'status,country,regionName,city' },
+        timeout: 3000
+      });
+      if (response.data?.status !== 'success') {
+        return empty;
+      }
+      return {
+        country: response.data.country ?? null,
+        region: response.data.regionName ?? null,
+        city: response.data.city ?? null
+      };
+    } catch (err) {
+      console.log(`GeoService.lookupLocation err: ${err}`);
+      return empty;
+    }
+  }
+}

--- a/mosaic-backend/lib/MosaicServices/ManifestService/ManifestService.ts
+++ b/mosaic-backend/lib/MosaicServices/ManifestService/ManifestService.ts
@@ -1,0 +1,87 @@
+import { Request, Response } from 'express';
+import env from '../../environment';
+import GeoService from '../GeoService/GeoService';
+const fs = require('fs');
+
+interface RenderEntry {
+  renderedAt: string;
+  numTiles: number;
+  scrubberFrame: string;
+}
+
+interface Manifest {
+  assetID: string;
+  uploadedAt: string;
+  location: { country: string | null; region: string | null; city: string | null };
+  renders: RenderEntry[];
+}
+
+export default class ManifestService {
+  private geoService: GeoService = new GeoService();
+
+  private manifestPath(assetID: string): string {
+    return `${env.getVolumnPath()}/${assetID}/manifest.json`;
+  }
+
+  private readManifest(assetID: string): Manifest | null {
+    try {
+      const raw = fs.readFileSync(this.manifestPath(assetID), 'utf8');
+      return JSON.parse(raw);
+    } catch (err) {
+      return null;
+    }
+  }
+
+  private writeManifest(assetID: string, manifest: Manifest) {
+    fs.writeFileSync(this.manifestPath(assetID), JSON.stringify(manifest, null, 2));
+  }
+
+  // called right after upload; writes the manifest immediately so the
+  // response isn't blocked, then fills in geolocation asynchronously
+  public createManifest (req: Request, res: Response, next: any) {
+    const assetID = res.locals.assetID;
+    const manifest: Manifest = {
+      assetID: String(assetID),
+      uploadedAt: new Date().toISOString(),
+      location: { country: null, region: null, city: null },
+      renders: []
+    };
+    try {
+      this.writeManifest(assetID, manifest);
+    } catch (err) {
+      console.log(`ManifestService.createManifest write err: ${err}`);
+    }
+    next();
+
+    const clientIp = req.ip?.replace(/^::ffff:/, '') ?? '';
+    this.geoService.lookupLocation(clientIp).then((location) => {
+      const current = this.readManifest(assetID);
+      if (!current) return;
+      current.location = location;
+      this.writeManifest(assetID, current);
+    });
+  }
+
+  // called after a successful render; records the edit choice made
+  public recordRender (assetID: string, numTiles: number, scrubberFrame: string) {
+    let manifest = this.readManifest(assetID);
+    if (!manifest) {
+      manifest = {
+        assetID: String(assetID),
+        uploadedAt: new Date().toISOString(),
+        location: { country: null, region: null, city: null },
+        renders: []
+      };
+    }
+    manifest.renders.push({
+      renderedAt: new Date().toISOString(),
+      numTiles,
+      scrubberFrame
+    });
+    try {
+      this.writeManifest(assetID, manifest);
+    } catch (err) {
+      console.log(`ManifestService.recordRender write err: ${err}`);
+    }
+  }
+}

--- a/mosaic-backend/lib/MosaicServices/S3Service/S3Service.ts
+++ b/mosaic-backend/lib/MosaicServices/S3Service/S3Service.ts
@@ -1,0 +1,74 @@
+import { S3Client, PutObjectCommand, GetObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import env from '../../environment';
+const fs = require('fs');
+
+export default class S3Service {
+  private client: S3Client;
+  private bucket: string;
+
+  constructor() {
+    this.bucket = env.getS3BucketName();
+    // credentials are resolved automatically from the EC2 instance's IAM role
+    this.client = new S3Client({ region: env.getAwsRegion() });
+  }
+
+  private assetKey(assetID: string, filename: string): string {
+    return `assets/${assetID}/${filename}`;
+  }
+
+  public async uploadAsset(assetID: string, localDir: string, filenames: string[]): Promise<void> {
+    for (const filename of filenames) {
+      const localPath = `${localDir}/${filename}`;
+      if (!fs.existsSync(localPath)) continue;
+      const body = fs.readFileSync(localPath);
+      await this.client.send(new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: this.assetKey(assetID, filename),
+        Body: body
+      }));
+    }
+  }
+
+  public async listAssetIDs(): Promise<string[]> {
+    const assetIDs = new Set<string>();
+    let continuationToken: string | undefined = undefined;
+    do {
+      const response = await this.client.send(new ListObjectsV2Command({
+        Bucket: this.bucket,
+        Prefix: 'assets/',
+        Delimiter: '/',
+        ContinuationToken: continuationToken
+      }));
+      (response.CommonPrefixes ?? []).forEach((p) => {
+        const match = p.Prefix?.match(/^assets\/([^/]+)\/$/);
+        if (match) assetIDs.add(match[1]);
+      });
+      continuationToken = response.NextContinuationToken;
+    } while (continuationToken);
+    return Array.from(assetIDs);
+  }
+
+  public async getManifest(assetID: string): Promise<any | null> {
+    try {
+      const response = await this.client.send(new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: this.assetKey(assetID, 'manifest.json')
+      }));
+      const body = await response.Body?.transformToString();
+      return body ? JSON.parse(body) : null;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  public async getSignedVideoUrl(assetID: string, filename: string, expiresInSeconds = 3600): Promise<string | null> {
+    try {
+      const command = new GetObjectCommand({ Bucket: this.bucket, Key: this.assetKey(assetID, filename) });
+      return await getSignedUrl(this.client, command, { expiresIn: expiresInSeconds });
+    } catch (err) {
+      console.log(`S3Service.getSignedVideoUrl err: ${err}`);
+      return null;
+    }
+  }
+}

--- a/mosaic-backend/lib/environment.ts
+++ b/mosaic-backend/lib/environment.ts
@@ -34,6 +34,18 @@ class Environment {
     }
 
   }
+
+  getS3BucketName(): string {
+    return process.env.S3_BUCKET_NAME || '';
+  }
+
+  getAwsRegion(): string {
+    return process.env.AWS_REGION || 'us-west-1';
+  }
+
+  getAdminPassword(): string {
+    return process.env.ADMIN_PASSWORD || '';
+  }
 }
 
 export default new Environment(Environments.local_environment);

--- a/mosaic-backend/lib/server.ts
+++ b/mosaic-backend/lib/server.ts
@@ -1,7 +1,12 @@
 import { httpServer } from "./App";
+import ArchiveService from "./MosaicServices/ArchiveService/ArchiveService";
 
 const PORT = 3001
+const ARCHIVE_SWEEP_INTERVAL_MS = 15 * 60 * 1000;
 
 httpServer.listen(PORT, () => {
    console.log('Express server listening on port ' + PORT);
 });
+
+const archiveService = new ArchiveService();
+setInterval(() => archiveService.sweep(), ARCHIVE_SWEEP_INTERVAL_MS);

--- a/mosaic-backend/package-lock.json
+++ b/mosaic-backend/package-lock.json
@@ -9,11 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.700.0",
+        "@aws-sdk/s3-request-presigner": "^3.700.0",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "axios": "^0.21.0",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "express": "^4.17.1",
+        "express-basic-auth": "^1.2.1",
         "express-fileupload": "^1.2.0",
         "ffprobe": "^1.1.2",
         "ffprobe-static": "^3.1.0",
@@ -24,7 +27,7 @@
       "devDependencies": {
         "@types/cors": "^2.8.9",
         "@types/express": "^4.17.9",
-        "@types/node": "^14.14.14",
+        "@types/node": "^20.14.0",
         "nodemon": "^2.0.2",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",
@@ -32,6 +35,439 @@
         "typescript": "^4.1.3",
         "webpack": "^5.11.0",
         "webpack-cli": "^4.2.0"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.12.tgz",
+      "integrity": "sha512-RgNDWfhNRIlNEzePIRrYTNi/6q+wwRMMapojn8YVzw4ZcJRa/gxVMtUbeZARR1gmopuv6oIhMbY7J66qIQ0ynw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/checksums/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1079.0.tgz",
+      "integrity": "sha512-di9U/7Po7qlVYb2dq58ULsbBAE1pBIk53rux+50LQCvH1X+/l1Ys+BIk/QLBtdaK1nADk0xRNEBbA1QWVnMccw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.12",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-node": "^3.972.62",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.58",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.27.tgz",
+      "integrity": "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.53.tgz",
+      "integrity": "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.55.tgz",
+      "integrity": "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.60.tgz",
+      "integrity": "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-env": "^3.972.53",
+        "@aws-sdk/credential-provider-http": "^3.972.55",
+        "@aws-sdk/credential-provider-login": "^3.972.59",
+        "@aws-sdk/credential-provider-process": "^3.972.53",
+        "@aws-sdk/credential-provider-sso": "^3.972.59",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.59.tgz",
+      "integrity": "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.62.tgz",
+      "integrity": "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.53",
+        "@aws-sdk/credential-provider-http": "^3.972.55",
+        "@aws-sdk/credential-provider-ini": "^3.972.60",
+        "@aws-sdk/credential-provider-process": "^3.972.53",
+        "@aws-sdk/credential-provider-sso": "^3.972.59",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.53.tgz",
+      "integrity": "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.59.tgz",
+      "integrity": "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/token-providers": "3.1079.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.59.tgz",
+      "integrity": "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.58.tgz",
+      "integrity": "sha512-6uaWRRYJGhOqc9EoTSbLDf9nI/doSAb5vAwGshs5/Hlv5Ce25b246lBkbRd/77fLAi+uMI1a70mJzVyLyCEufQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.27.tgz",
+      "integrity": "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1079.0.tgz",
+      "integrity": "sha512-NfHUaND7WyLUPkO7HCF3MFg4bdscY34A4tm4dPWa31qYzhGNZarRPr/CcRgllxzPoOSD/EHfZ4fQtZnMl2xWFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1079.0.tgz",
+      "integrity": "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -273,6 +709,123 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
+      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
+      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
+      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
+      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
+      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -398,9 +951,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.9.17",
@@ -856,6 +1413,24 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -908,6 +1483,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1667,6 +2248,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-basic-auth": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
+      "integrity": "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1"
       }
     },
     "node_modules/express-fileupload": {
@@ -3809,6 +4399,12 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/mosaic-backend/package.json
+++ b/mosaic-backend/package.json
@@ -11,11 +11,14 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.700.0",
+    "@aws-sdk/s3-request-presigner": "^3.700.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "axios": "^0.21.0",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "express-basic-auth": "^1.2.1",
     "express-fileupload": "^1.2.0",
     "ffprobe": "^1.1.2",
     "ffprobe-static": "^3.1.0",
@@ -26,7 +29,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.9",
     "@types/express": "^4.17.9",
-    "@types/node": "^14.14.14",
+    "@types/node": "^20.14.0",
     "nodemon": "^2.0.2",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",

--- a/mosaic-backend/public/admin/index.html
+++ b/mosaic-backend/public/admin/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Mosaic - Asset Report</title>
+<style>
+  body { font-family: -apple-system, Helvetica, Arial, sans-serif; margin: 2rem; background: #14151a; color: #e6e6e6; }
+  h1 { font-size: 1.4rem; margin-bottom: 1rem; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #2c2d33; vertical-align: top; }
+  th { color: #9aa0a6; font-weight: 600; }
+  tr:hover { background: #1c1d22; }
+  .muted { color: #7a7f87; }
+  button { background: #2c2d33; color: #e6e6e6; border: 1px solid #3a3b42; border-radius: 4px; padding: 0.3rem 0.6rem; cursor: pointer; font-size: 0.85rem; margin-right: 0.4rem; }
+  button:hover { background: #3a3b42; }
+  video { max-width: 240px; display: block; margin-top: 0.4rem; border-radius: 4px; }
+  #status { color: #7a7f87; margin-bottom: 1rem; }
+</style>
+</head>
+<body>
+  <h1>Mosaic - Asset Report</h1>
+  <div id="status">Loading...</div>
+  <table id="assetTable" style="display:none">
+    <thead>
+      <tr>
+        <th>Uploaded</th>
+        <th>Location</th>
+        <th>Latest Edit</th>
+        <th>Original</th>
+        <th>Rendered</th>
+      </tr>
+    </thead>
+    <tbody id="assetRows"></tbody>
+  </table>
+
+  <script>
+    async function fetchVideoUrl(assetID, filename) {
+      const response = await fetch(`/admin/api/video-url?assetID=${encodeURIComponent(assetID)}&filename=${encodeURIComponent(filename)}`);
+      if (!response.ok) return null;
+      const data = await response.json();
+      return data.url;
+    }
+
+    function formatLocation(location) {
+      if (!location) return '<span class="muted">unknown</span>';
+      const parts = [location.city, location.region, location.country].filter(Boolean);
+      return parts.length ? parts.join(', ') : '<span class="muted">unknown</span>';
+    }
+
+    function formatLatestEdit(renders) {
+      if (!renders || renders.length === 0) return '<span class="muted">not rendered</span>';
+      const latest = renders[renders.length - 1];
+      return `${latest.numTiles} tiles, frame ${latest.scrubberFrame}<br><span class="muted">${new Date(latest.renderedAt).toLocaleString()}</span>`;
+    }
+
+    function makeVideoCell(assetID, filename, label) {
+      const cell = document.createElement('td');
+      const button = document.createElement('button');
+      button.textContent = label;
+      button.onclick = async () => {
+        button.textContent = 'Loading...';
+        const url = await fetchVideoUrl(assetID, filename);
+        if (!url) {
+          button.textContent = 'Not available';
+          return;
+        }
+        button.remove();
+        const video = document.createElement('video');
+        video.src = url;
+        video.controls = true;
+        cell.appendChild(video);
+      };
+      cell.appendChild(button);
+      return cell;
+    }
+
+    async function load() {
+      const statusEl = document.getElementById('status');
+      try {
+        const response = await fetch('/admin/api/assets');
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = await response.json();
+        const rows = document.getElementById('assetRows');
+        rows.innerHTML = '';
+        data.assets.forEach((asset) => {
+          const row = document.createElement('tr');
+
+          const uploadedCell = document.createElement('td');
+          uploadedCell.textContent = new Date(asset.uploadedAt).toLocaleString();
+          row.appendChild(uploadedCell);
+
+          const locationCell = document.createElement('td');
+          locationCell.innerHTML = formatLocation(asset.location);
+          row.appendChild(locationCell);
+
+          const editCell = document.createElement('td');
+          editCell.innerHTML = formatLatestEdit(asset.renders);
+          row.appendChild(editCell);
+
+          row.appendChild(makeVideoCell(asset.assetID, 'upload.mov', 'View original'));
+          row.appendChild(makeVideoCell(asset.assetID, 'mosaic.mov', 'View rendered'));
+
+          rows.appendChild(row);
+        });
+
+        statusEl.style.display = 'none';
+        document.getElementById('assetTable').style.display = data.assets.length ? 'table' : 'none';
+        if (!data.assets.length) {
+          statusEl.style.display = 'block';
+          statusEl.textContent = 'No archived assets yet.';
+        }
+      } catch (err) {
+        statusEl.textContent = `Failed to load assets: ${err.message}`;
+      }
+    }
+
+    load();
+  </script>
+</body>
+</html>

--- a/mosaic-proxy/default.conf
+++ b/mosaic-proxy/default.conf
@@ -9,6 +9,9 @@ upstream frontend {
 server {
     listen       80;
 
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
@@ -30,6 +33,10 @@ server {
 
     location /render/mosaic {
         proxy_pass http://backend/render/mosaic;
+    }
+
+    location /admin {
+        proxy_pass http://backend/admin;
     }
 
     location /socket.io/ {


### PR DESCRIPTION
## Summary
Adds the ability to view uploaded videos, the edits users make, and uploader location from a laptop browser outside the app, as requested.

- **GeoService**: looks up country/region/city from the uploader's IP via a free geolocation API (`ip-api.com`), called asynchronously *after* the upload response so it never adds latency to the upload flow.
- **ManifestService**: persists a per-asset `manifest.json` (upload time, location, and a history of render attempts with tile count + scrubber frame chosen) alongside each asset's video files.
- **S3Service + ArchiveService**: archives each asset's original/rendered video and manifest to S3 immediately after a successful render (local copy is kept so the user can keep re-rendering the same session), plus a 15-minute background sweep that finally uploads and deletes any local asset folder inactive for over an hour. This doubles as a fix for the disk-space problem from the old manual deploy process, going forward.
- **AdminRoutes + `public/admin`**: a small password-protected (HTTP Basic Auth, single shared password) page at `/admin` listing archived assets with location, latest edit, and signed-URL video playback for both the original upload and the rendered mosaic.
- nginx now forwards `X-Real-IP`/`X-Forwarded-For`; Express trusts the proxy so `req.ip` reflects the real client IP instead of the container's.
- Bumped `@types/node` from `^14` to `^20` to match the runtime (needed for the AWS SDK's type dependencies).

## Security/credentials
No AWS credentials are embedded anywhere — the backend picks up S3 access automatically from the EC2 instance's IAM role via the AWS SDK's default credential provider chain. Every S3/geolocation call is wrapped so failures are caught and logged rather than breaking the core upload/render flow (important since this needs to be safe to merge *before* the S3 bucket/IAM role exist).

## Before this is fully live
Three new GitHub secrets need to be set once the AWS side is ready: `S3_BUCKET_NAME`, `AWS_REGION`, `ADMIN_PASSWORD`.

## Test plan
- [x] Backend type-checks and builds cleanly (`tsc -p .`) with the bumped `@types/node`
- [ ] After AWS setup + secrets are in place, redeploy and confirm: upload → archive → `/admin` shows the asset with location and edit history; video playback works via signed URL
- [ ] Confirm the app's core upload/render flow is unaffected when `S3_BUCKET_NAME` is unset (local dev / before secrets exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)