### PR TITLE
Cache rendered videos, add admin thumbnails, fix frontend cache headers

### DIFF
--- a/mosaic-backend/lib/MosaicController.ts
+++ b/mosaic-backend/lib/MosaicController.ts
@@ -21,18 +21,22 @@ export class MosaicController {
 
   public recordRender (req: Request, res: Response, next: any) {
     const assetID = String(req.query.assetID);
+    const outputFilename = String(res.locals.outputFilename);
+    const thumbnailFilename = String(res.locals.thumbnailFilename);
     this.manifestService.recordRender(
       assetID,
       Number(req.query.numTiles),
-      String(req.query.currentScrubberFrame)
+      String(req.query.currentScrubberFrame),
+      outputFilename
     );
     next();
 
     // archive right away so the report reflects recent activity without
     // waiting for the periodic sweep; local copy is left in place so the
-    // user can keep re-rendering this asset in the same session
+    // user can keep re-rendering this asset in the same session.
+    // img001.jpg (from exportFrames) doubles as the original-video thumbnail.
     const assetDir = `${env.getVolumnPath()}/${assetID}`;
-    this.s3Service.uploadAsset(assetID, assetDir, ['upload.mov', 'mosaic.mov', 'manifest.json'])
+    this.s3Service.uploadAsset(assetID, assetDir, ['upload.mov', 'img001.jpg', outputFilename, thumbnailFilename, 'manifest.json'])
       .catch((err) => console.log(`recordRender S3 archive err: ${err}`));
   }
 

--- a/mosaic-backend/lib/MosaicRoutes.ts
+++ b/mosaic-backend/lib/MosaicRoutes.ts
@@ -24,7 +24,7 @@ export class MosaicRoutes {
       },
       (req, res, next) => this.mosaicController.renderMosaic(req, res, next),
       (req, res, next) => this.mosaicController.recordRender(req, res, next),
-      (req, res, next) => res.download(`${env.getVolumnPath()}/${req.query.assetID}/mosaic.mov`)
+      (req, res, next) => res.download(`${env.getVolumnPath()}/${req.query.assetID}/${res.locals.outputFilename}`)
     );
      
     app.all('*', 

--- a/mosaic-backend/lib/MosaicServices/ArchiveService/ArchiveService.ts
+++ b/mosaic-backend/lib/MosaicServices/ArchiveService/ArchiveService.ts
@@ -35,7 +35,9 @@ export default class ArchiveService {
       if (age < ASSET_MAX_AGE_MS) continue;
 
       try {
-        await this.s3Service.uploadAsset(assetID, assetDir, ['upload.mov', 'mosaic.mov', 'manifest.json']);
+        // covers both mosaic_*.mov render variants and their mosaic_*.jpg thumbnails
+        const renderVariants = fs.readdirSync(assetDir).filter((f: string) => f.startsWith('mosaic_'));
+        await this.s3Service.uploadAsset(assetID, assetDir, ['upload.mov', 'img001.jpg', 'manifest.json', ...renderVariants]);
         fs.rmSync(assetDir, { recursive: true, force: true });
         console.log(`ArchiveService.sweep archived and removed asset ${assetID}`);
       } catch (err) {

--- a/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
@@ -6,6 +6,7 @@ import { createFfmpegFilterComplexStr } from './utils/createFfmpegFilterComplexS
 import env from '../../environment';
 import { Request, Response } from 'express';
 import { io } from '../../App';
+const fs = require('fs');
 
 export default class FFmpegService {
   public probeVideo (req: Request, res: Response, next: any) {
@@ -149,7 +150,24 @@ export default class FFmpegService {
     const inputPath  = `${env.getVolumnPath()}/${assetID}/cropped.mov`;
     const bgImagePath = `${env.getVolumnPath()}/${assetID}/${res.locals.currentScrubberFrame}`;
     const outputDirectory = `${env.getVolumnPath()}/${assetID}`;
-    const outputPath = `${outputDirectory}/mosaic.mov`;
+    // cache key is the source video (assetID) + background frame + tile
+    // pattern; an identical combination has already produced this exact
+    // output, so it's safe to reuse it instead of re-encoding
+    const scrubberFrameBase = String(res.locals.currentScrubberFrame).replace(/\.[^/.]+$/, '');
+    const outputFilename = `mosaic_${res.locals.numTiles}_${scrubberFrameBase}.mov`;
+    const outputPath = `${outputDirectory}/${outputFilename}`;
+    const thumbnailFilename = outputFilename.replace(/\.mov$/, '.jpg');
+    const thumbnailPath = `${outputDirectory}/${thumbnailFilename}`;
+    res.locals.outputFilename = outputFilename;
+    res.locals.thumbnailFilename = thumbnailFilename;
+
+    if (fs.existsSync(outputPath)) {
+      console.log(`renderMosaic: reusing cached render at ${outputPath}`);
+      res.locals.status = 'success';
+      this.generateThumbnail(outputPath, thumbnailPath).then(() => next());
+      return;
+    }
+
     const ffmpegFilterComplexStr = createFfmpegFilterComplexStr(filterParams);
     const proc = spawn(ffmpeg.path, ['-i', bgImagePath, '-i', inputPath, '-filter_complex', ffmpegFilterComplexStr, '-preset', 'veryfast', '-crf', '26', '-map', '[final]', '-an', '-y', outputPath]);
     // @ts-ignore: Object is possibly 'null'.
@@ -165,10 +183,27 @@ export default class FFmpegService {
         io.emit('ffmpegProgress', { actionName: 'Rendering', currentFrame: lines[1], totalFrames: totalOutputFrames });
       }
     });
-    proc.on('close', function() {
+    proc.on('close', () => {
       res.locals.status = 'success';
       console.log(`renderMosaic : proc.on('close')`);
-      next();
+      this.generateThumbnail(outputPath, thumbnailPath).then(() => next());
+    });
+  }
+
+  // grabs a single frame from a rendered video for use as an admin-report thumbnail;
+  // failures are swallowed so a broken thumbnail never blocks the render response
+  private generateThumbnail (videoPath: string, thumbnailPath: string): Promise<void> {
+    return new Promise((resolve) => {
+      if (fs.existsSync(thumbnailPath)) {
+        resolve();
+        return;
+      }
+      const proc = spawn(ffmpeg.path, ['-i', videoPath, '-ss', '1', '-frames:v', '1', '-y', thumbnailPath]);
+      proc.on('close', () => resolve());
+      proc.on('error', (err) => {
+        console.log(`generateThumbnail err: ${err}`);
+        resolve();
+      });
     });
   }
 

--- a/mosaic-backend/lib/MosaicServices/ManifestService/ManifestService.ts
+++ b/mosaic-backend/lib/MosaicServices/ManifestService/ManifestService.ts
@@ -7,6 +7,7 @@ interface RenderEntry {
   renderedAt: string;
   numTiles: number;
   scrubberFrame: string;
+  outputFilename: string;
 }
 
 interface Manifest {
@@ -62,8 +63,8 @@ export default class ManifestService {
     });
   }
 
-  // called after a successful render; records the edit choice made
-  public recordRender (assetID: string, numTiles: number, scrubberFrame: string) {
+  // called after a successful render (cache hit or fresh encode); records the edit choice made
+  public recordRender (assetID: string, numTiles: number, scrubberFrame: string, outputFilename: string) {
     let manifest = this.readManifest(assetID);
     if (!manifest) {
       manifest = {
@@ -76,7 +77,8 @@ export default class ManifestService {
     manifest.renders.push({
       renderedAt: new Date().toISOString(),
       numTiles,
-      scrubberFrame
+      scrubberFrame,
+      outputFilename
     });
     try {
       this.writeManifest(assetID, manifest);

--- a/mosaic-backend/public/admin/index.html
+++ b/mosaic-backend/public/admin/index.html
@@ -11,10 +11,31 @@
   th { color: #9aa0a6; font-weight: 600; }
   tr:hover { background: #1c1d22; }
   .muted { color: #7a7f87; }
-  button { background: #2c2d33; color: #e6e6e6; border: 1px solid #3a3b42; border-radius: 4px; padding: 0.3rem 0.6rem; cursor: pointer; font-size: 0.85rem; margin-right: 0.4rem; }
-  button:hover { background: #3a3b42; }
-  video { max-width: 240px; display: block; margin-top: 0.4rem; border-radius: 4px; }
   #status { color: #7a7f87; margin-bottom: 1rem; }
+
+  .thumb {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    border-radius: 6px;
+    overflow: hidden;
+    background: #23242b;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .thumb .placeholder { color: #7a7f87; font-size: 0.75rem; text-align: center; padding: 0.5rem; }
+  .thumb .play-overlay {
+    position: absolute; inset: 0;
+    display: flex; align-items: center; justify-content: center;
+    background: rgba(0,0,0,0.25);
+    color: white; font-size: 1.8rem;
+    pointer-events: none;
+  }
+  .thumb:hover .play-overlay { background: rgba(0,0,0,0.4); }
+  video { width: 120px; height: 120px; object-fit: cover; border-radius: 6px; display: block; }
 </style>
 </head>
 <body>
@@ -34,7 +55,7 @@
   </table>
 
   <script>
-    async function fetchVideoUrl(assetID, filename) {
+    async function fetchSignedUrl(assetID, filename) {
       const response = await fetch(`/admin/api/video-url?assetID=${encodeURIComponent(assetID)}&filename=${encodeURIComponent(filename)}`);
       if (!response.ok) return null;
       const data = await response.json();
@@ -53,24 +74,45 @@
       return `${latest.numTiles} tiles, frame ${latest.scrubberFrame}<br><span class="muted">${new Date(latest.renderedAt).toLocaleString()}</span>`;
     }
 
-    function makeVideoCell(assetID, filename, label) {
+    // renders a thumbnail that swaps itself out for a playing <video> on click.
+    // videoFilename is fetched lazily (only when clicked); thumbnailFilename is
+    // fetched immediately so the grid has something to show right away.
+    function makeThumbnailCell(assetID, videoFilename, thumbnailFilename) {
       const cell = document.createElement('td');
-      const button = document.createElement('button');
-      button.textContent = label;
-      button.onclick = async () => {
-        button.textContent = 'Loading...';
-        const url = await fetchVideoUrl(assetID, filename);
+      const thumb = document.createElement('div');
+      thumb.className = 'thumb';
+      thumb.innerHTML = '<span class="placeholder">Loading...</span>';
+      cell.appendChild(thumb);
+
+      fetchSignedUrl(assetID, thumbnailFilename).then((url) => {
+        thumb.innerHTML = '';
+        if (url) {
+          const img = document.createElement('img');
+          img.src = url;
+          thumb.appendChild(img);
+        } else {
+          thumb.innerHTML = '<span class="placeholder">Click to play</span>';
+        }
+        const overlay = document.createElement('div');
+        overlay.className = 'play-overlay';
+        overlay.textContent = '▶';
+        thumb.appendChild(overlay);
+      });
+
+      thumb.onclick = async () => {
+        thumb.innerHTML = '<span class="placeholder">Loading...</span>';
+        const url = await fetchSignedUrl(assetID, videoFilename);
         if (!url) {
-          button.textContent = 'Not available';
+          thumb.innerHTML = '<span class="placeholder">Not available</span>';
           return;
         }
-        button.remove();
         const video = document.createElement('video');
         video.src = url;
         video.controls = true;
-        cell.appendChild(video);
+        video.autoplay = true;
+        thumb.replaceWith(video);
       };
-      cell.appendChild(button);
+
       return cell;
     }
 
@@ -97,8 +139,12 @@
           editCell.innerHTML = formatLatestEdit(asset.renders);
           row.appendChild(editCell);
 
-          row.appendChild(makeVideoCell(asset.assetID, 'upload.mov', 'View original'));
-          row.appendChild(makeVideoCell(asset.assetID, 'mosaic.mov', 'View rendered'));
+          const latestRender = asset.renders && asset.renders.length ? asset.renders[asset.renders.length - 1] : null;
+          const renderedFilename = (latestRender && latestRender.outputFilename) || 'mosaic.mov';
+          const renderedThumbnailFilename = renderedFilename.replace(/\.mov$/, '.jpg');
+
+          row.appendChild(makeThumbnailCell(asset.assetID, 'upload.mov', 'img001.jpg'));
+          row.appendChild(makeThumbnailCell(asset.assetID, renderedFilename, renderedThumbnailFilename));
 
           rows.appendChild(row);
         });

--- a/mosaic-frontend/nginx/default.conf
+++ b/mosaic-frontend/nginx/default.conf
@@ -4,5 +4,13 @@ server {
   location / {
     root /usr/share/nginx/html;
     index index.html index.htm;
+    add_header Cache-Control "no-cache";
+  }
+
+  # Vite content-hashes these filenames, so they can be cached indefinitely -
+  # a new deploy always ships a new filename, never a stale one.
+  location /assets/ {
+    root /usr/share/nginx/html;
+    add_header Cache-Control "public, max-age=31536000, immutable";
   }
 }


### PR DESCRIPTION
## Summary

**1. Render caching** (reuse instead of re-encoding when nothing changed): `renderMosaic`'s output filename is now derived from its actual cache key - `mosaic_<numTiles>_<scrubberFrame>.mov` - instead of a single fixed `mosaic.mov` that got overwritten on every render. If that exact combination of source video + background frame + tile pattern has already been rendered, the existing file is served directly and ffmpeg is skipped entirely. Updated everywhere that assumed a fixed filename: manifest render history, the download route, the immediate post-render S3 archive, and the periodic archive sweep (all now handle however many distinct render variants exist per asset).

**2. Admin report thumbnails**: replaced the plain "View original"/"View rendered" buttons with actual clickable thumbnail previews that swap themselves for a playing `<video>` on click.
- Original thumbnail reuses `img001.jpg`, already produced during upload processing - no new encoding work.
- Rendered thumbnail is a new single-frame ffmpeg grab taken right after each render completes (or already present on a cache hit, so repeats cost nothing extra).

**3. Frontend cache headers**: added explicit `Cache-Control` in the frontend's nginx config - `index.html` always revalidates, while Vite's content-hashed `/assets/*` files are cached long-term (safe since a new build always ships a new filename). This addresses a report that the previous download-filename fix appeared not to be live; turned out to be a stale browser cache of the old JS bundle - confirmed by grepping the actually-deployed bundle, which already had the fix.

## Test plan
- [x] Backend type-checks cleanly
- [ ] After deploy: render the same asset/frame/tile-count combo twice, confirm the second request is near-instant (cache hit) and doesn't emit `ffmpegProgress` events
- [ ] Confirm the admin report shows thumbnails for both original and rendered video, and clicking either plays it
- [ ] Confirm re-rendering with a *different* tile count or frame still produces a fresh (correct) output rather than reusing a mismatched cache entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)