### PR TITLE
Fix 9:16 controls clipped on mobile browsers

### DIFF
--- a/mosaic-frontend/src/App.tsx
+++ b/mosaic-frontend/src/App.tsx
@@ -17,7 +17,7 @@ import {
 // slices
 import { setScrubberCanvasWidth } from '@/components/Scrubber/scrubber.slice';
 import { setCanvasWidth, setUiVisible } from './app.slice';
-import { appDimensions } from './app.config';
+import { appDimensions, isMobileDevice } from './app.config';
 // interfaces
 import { AppState } from '@interfaces/AppState';
 import { NavState } from '@interfaces/NavState';
@@ -50,8 +50,8 @@ const App: React.FC = () => {
           { isInAppBrowser && <InAppPrompt /> }
           { !isInAppBrowser &&
           <div
-            className={`app_stage ${is9x16 ? 'app_stage--9x16' : ''}`}
-            style={is9x16 ? { width: appDimensions.popOver.width, height: appDimensions.popOver.height } : undefined}
+            className={`app_stage ${is9x16 ? 'app_stage--9x16' : ''} ${is9x16 && isMobileDevice ? 'app_stage--9x16-device' : ''}`}
+            style={is9x16 && !isMobileDevice ? { width: appDimensions.popOver.width, height: appDimensions.popOver.height } : undefined}
           >
             <RenderMosaic
                 displaySize={appDimensions.popOver}

--- a/mosaic-frontend/src/app.config.ts
+++ b/mosaic-frontend/src/app.config.ts
@@ -1,7 +1,9 @@
 import isMobile from 'is-mobile';
 
-const [width, uiContainerHeight] = isMobile({ tablet: true }) 
-  ? [window.innerWidth, window.innerHeight - window.innerWidth] 
+const isMobileDevice = isMobile({ tablet: true });
+
+const [width, uiContainerHeight] = isMobileDevice
+  ? [window.innerWidth, window.innerHeight - window.innerWidth]
   : [414, 302];
 
 const popOverHeight = width + uiContainerHeight;
@@ -51,6 +53,7 @@ const mosaicTileConfig = {
 
 export {
   appDimensions,
+  isMobileDevice,
   MAX_VIDEO_UPLOAD_DURATION,
   SCRUBBER_FRAMES_MAX,
   DEFAULT_VIDEO_NUM_TILES,

--- a/mosaic-frontend/src/app.css
+++ b/mosaic-frontend/src/app.css
@@ -32,6 +32,16 @@ html, body, .full_size {
   background: #000;
 }
 
+/* On a device, size the 9:16 stage to the dynamic viewport so the bottom
+   controls are never clipped behind the browser's address/tool bars. dvh
+   tracks the visible area as the browser chrome shows/hides; vh is the
+   fallback for browsers without dvh support. (Desktop keeps fixed mock dims.) */
+.app_stage--9x16-device {
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+}
+
 .video_area--9x16 {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Problem
On mobile (reported on Chrome iOS), the 9:16 editor controls (navigation row) are clipped behind the browser's bottom toolbar.

## Cause
The mobile 9:16 stage height was a fixed pixel value captured from `window.innerHeight` at page load. iOS dynamic browser toolbars make that value taller than the actually-visible area, so the stage extends behind the browser chrome and the bottom controls fall outside the viewport.

## Fix
Size the mobile 9:16 stage with `100dvh` (dynamic viewport height, which tracks the browser chrome as it shows/hides), with `100vh` as a fallback. Desktop keeps its fixed iPhone-mock dimensions.

- `app.config.ts`: export `isMobileDevice`.
- `App.tsx`: mobile 9:16 uses the `.app_stage--9x16-device` class; desktop 9:16 keeps inline mock dims.
- `app.css`: `.app_stage--9x16-device { width:100vw; height:100vh; height:100dvh; }`

tsc + vite build pass; `dvh` rule confirmed in the built bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)