### PR TITLE
Bump deploy workflow actions to Node 24 versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,23 +22,23 @@ jobs:
       image_tag: ${{ steps.tag.outputs.image_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Resolve image tag
         id: tag
         run: echo "image_tag=${{ inputs.image_tag || github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./mosaic-backend
           push: true
@@ -47,7 +47,7 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/mosaic-backend:latest
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./mosaic-frontend
           push: true
@@ -56,7 +56,7 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/mosaic-frontend:latest
 
       - name: Build and push proxy image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./mosaic-proxy
           push: true
@@ -70,7 +70,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Deploy to EC2
         env:


### PR DESCRIPTION
## Summary
Resolves the GitHub Actions **Node 20 deprecation warning** seen in the deploy workflow, by bumping to the latest major versions of each action — all confirmed to run on `node24` (verified via each action's `action.yml` `runs.using`).

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |

Workflow-file-only change; no application code affected. The updated actions take effect on the next `deploy.yaml` run (no deploy required to "apply" this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)