### PR TITLE
Fix 9:16 preview video not rendering on iOS

### DIFF
--- a/mosaic-frontend/src/app.config.ts
+++ b/mosaic-frontend/src/app.config.ts
@@ -14,8 +14,15 @@ const DEFAULT_VIDEO_NUM_TILES = 4;
 
 // height multiplier applied to the (square) canvas width for each aspect ratio
 const ASPECT_HEIGHT_MULTIPLIER: { [key: string]: number } = { '1x1': 1, '9x16': 16 / 9 };
-const getAspectHeight = (width: number, aspectRatio: string): number =>
-  Math.round(width * (ASPECT_HEIGHT_MULTIPLIER[aspectRatio] ?? 1));
+const getAspectHeight = (width: number, aspectRatio: string): number => {
+  const raw = Math.round(width * (ASPECT_HEIGHT_MULTIPLIER[aspectRatio] ?? 1));
+  // The 9:16 preview/render sources are H.264 (even dimensions, e.g. 320x568),
+  // so the height must be rounded to an even number. Otherwise the odd value
+  // (e.g. 569) makes each tile's canvas copy region 1px taller than the source
+  // video; iOS/WebKit throws on a drawImage source rect that exceeds the video,
+  // which kills the preview animation. 1:1 is square, so leave it exact.
+  return aspectRatio === '9x16' ? raw - (raw % 2) : raw;
+};
 
 const appDimensions = {
   popOver: { width, height: popOverHeight },

--- a/mosaic-frontend/src/components/MosaicTiles/MosaicTile.ts
+++ b/mosaic-frontend/src/components/MosaicTiles/MosaicTile.ts
@@ -118,21 +118,30 @@ class MosaicTile implements Partial<MosaicTileProps> {
   
   _drawImage() {
     this._context.clearRect(
-      this._drawToCanvasArea.x, 
-      this._drawToCanvasArea.y, 
-      this._drawToCanvasArea.width, 
+      this._drawToCanvasArea.x,
+      this._drawToCanvasArea.y,
+      this._drawToCanvasArea.width,
       this._drawToCanvasArea.height
     );
     this._context.globalAlpha = this._fadeOpacity ?? 1;
+    // Clamp the source rectangle to the video's actual dimensions. A source
+    // rect that exceeds the video throws on iOS/WebKit and silently clips
+    // elsewhere; clamping keeps drawImage safe on every engine.
+    const videoWidth = this._video.videoWidth || this._copyVideoFromArea.width;
+    const videoHeight = this._video.videoHeight || this._copyVideoFromArea.height;
+    const sx = Math.min(this._copyVideoFromArea.x, videoWidth);
+    const sy = Math.min(this._copyVideoFromArea.y, videoHeight);
+    const sWidth = Math.min(this._copyVideoFromArea.width, videoWidth - sx);
+    const sHeight = Math.min(this._copyVideoFromArea.height, videoHeight - sy);
     this._context.drawImage(
     this._video,
-      this._copyVideoFromArea.x, 
-      this._copyVideoFromArea.y, 
-      this._copyVideoFromArea.width, 
-      this._copyVideoFromArea.height,
-      this._drawToCanvasArea.x, 
-      this._drawToCanvasArea.y, 
-      this._drawToCanvasArea.width, 
+      sx,
+      sy,
+      sWidth,
+      sHeight,
+      this._drawToCanvasArea.x,
+      this._drawToCanvasArea.y,
+      this._drawToCanvasArea.width,
       this._drawToCanvasArea.height
     );
   }


### PR DESCRIPTION
## Problem
On iPhone, in 9:16 mode the scrubber background images show but the mosaic tiles (drawn from the preview video) don't render. 1:1 works fine.

## Root cause
Both preview videos are encoded identically — the only difference is dimensions: 1:1 is 320×**320**, 9:16 is 320×**568** (H.264 requires even dimensions). But `getAspectHeight(320, '9x16')` returned `round(320×16/9)` = **569**, so every 9:16 tile's canvas copy region was 1px taller than the source video.

- Desktop Chrome silently clips a `drawImage` source rect that exceeds the source.
- **iOS/WebKit throws** on it, which kills the preview animation loop on the first frame → no tiles.
- 1:1 has no overshoot (320 = 320), so it was unaffected.

## Fix
- `getAspectHeight`: round the 9:16 height **down to an even number** (568) so it matches the real video dimensions exactly.
- `MosaicTile._drawImage`: defensively **clamp the source rectangle** to the video's actual `videoWidth`/`videoHeight`, so `drawImage` is safe on every engine regardless of any future dimension mismatch.

tsc + vite build pass. This bug only reproduces on a real mobile WebKit browser, so it needs verification on-device after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)