### PR TITLE
Add background carousel mode (frontend + FFmpeg)

### DIFF
--- a/assets/330055/.gitignore
+++ b/assets/330055/.gitignore
@@ -1,3 +1,4 @@
 # runtime render cache + per-asset manifest (regenerated on demand)
 mosaic_*
+bg_carousel*
 manifest.json

--- a/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
@@ -3,6 +3,8 @@ import ffmpeg from '@ffmpeg-installer/ffmpeg';
 import ffprobe from 'ffprobe';
 import ffprobeStatic from 'ffprobe-static';
 import { createFfmpegFilterComplexStr } from './utils/createFfmpegFilterComplexStr';
+import createCarouselFilter from './utils/createCarouselFilter';
+import { SCRUBBER_FRAME_COUNT } from './configs';
 import env from '../../environment';
 import { Request, Response } from 'express';
 import { io } from '../../App';
@@ -132,15 +134,18 @@ export default class FFmpegService {
     const assetID = res.locals.assetID
     const dir = `${env.getVolumnPath()}/${assetID}`;
     const { duration, totalFrames } = res.locals.videoUpload;
-    const frameInterval = 18 / (duration - 1);
+    // sample at a rate that yields more than SCRUBBER_FRAME_COUNT frames across
+    // the clip, then cap the output at exactly that many evenly-spaced frames.
+    const frameInterval = SCRUBBER_FRAME_COUNT / (duration - 1);
+    const frameCap = SCRUBBER_FRAME_COUNT.toString();
 
     Promise.all([
       this.runFfmpeg(
-        ['-i', `${dir}/cropped.mov`, '-vf', 'hue=s=0.1', '-r', frameInterval.toString(), '-preset', 'ultrafast', '-crf', '28', `${dir}/img%03d.jpg`],
+        ['-i', `${dir}/cropped.mov`, '-vf', 'hue=s=0.1', '-r', frameInterval.toString(), '-frames:v', frameCap, '-preset', 'ultrafast', '-crf', '28', `${dir}/img%03d.jpg`],
         (frame) => io.emit('ffmpegProgress', { actionName: 'Export frame', currentFrame: frame, totalFrames })
       ),
       this.runFfmpeg(
-        ['-i', `${dir}/cropped_9x16.mov`, '-vf', 'hue=s=0.1', '-r', frameInterval.toString(), '-preset', 'ultrafast', '-crf', '28', `${dir}/img%03d_9x16.jpg`]
+        ['-i', `${dir}/cropped_9x16.mov`, '-vf', 'hue=s=0.1', '-r', frameInterval.toString(), '-frames:v', frameCap, '-preset', 'ultrafast', '-crf', '28', `${dir}/img%03d_9x16.jpg`]
       )
     ]).then(() => {
       res.locals.status = 'success';
@@ -153,10 +158,10 @@ export default class FFmpegService {
   public renderMosaic  (req: Request, res: Response, next: any) {
     const aspectRatio: AspectRatio = res.locals.aspectRatio === '9x16' ? '9x16' : '1x1';
     const { size: outputSize, cropped: croppedName } = ASPECT_OUTPUT[aspectRatio];
+    // carousel mode dissolves through every background frame instead of holding
+    // a single scrubber-selected still (query param sent by the frontend)
+    const carousel = String(res.locals.carousel) === 'true';
 
-    const duration = res.locals.videoUpload.duration - 1;
-    const frameInterval = duration / 18;
-    const bgFrameStart = (res.locals.currentScrubberFrame - 1) * frameInterval;
     const inputDuration = res.locals.videoUpload.duration;
     const outputFps = 25;
     const filterParams = {
@@ -186,10 +191,13 @@ export default class FFmpegService {
     // tile pattern; an identical combination has already produced this exact
     // output, so it's safe to reuse instead of re-encoding
     const scrubberFrameBase = baseFrame.replace(/\.[^/.]+$/, '').replace(/_9x16$/, '');
+    // carousel renders are independent of the selected still, so they key on a
+    // 'carousel' token instead of a frame number.
+    const frameToken = carousel ? 'carousel' : scrubberFrameBase;
     // version segment in the cache key: bump it whenever the render output
     // changes visually (e.g. the white grid) so pre-change cached renders are
     // never reused for identical source/frame/tile params. 'g' = grid lines.
-    const outputFilename = `mosaic_g_${aspectRatio}_${res.locals.numTiles}_${scrubberFrameBase}.mov`;
+    const outputFilename = `mosaic_g_${aspectRatio}_${res.locals.numTiles}_${frameToken}.mov`;
     const outputPath = `${outputDirectory}/${outputFilename}`;
     const thumbnailFilename = outputFilename.replace(/\.mov$/, '.jpg');
     const thumbnailPath = `${outputDirectory}/${thumbnailFilename}`;
@@ -205,7 +213,32 @@ export default class FFmpegService {
     }
 
     const ffmpegFilterComplexStr = createFfmpegFilterComplexStr(filterParams);
-    const proc = spawn(ffmpeg.path, ['-i', bgImagePath, '-i', inputPath, '-filter_complex', ffmpegFilterComplexStr, '-preset', 'veryfast', '-crf', '26', '-map', '[out]', '-an', '-y', outputPath]);
+
+    // carousel mode needs its animated background built (once per asset+aspect,
+    // then cached) before the main render can composite the tiles over it; the
+    // still path uses the single scrubber frame directly.
+    if (carousel) {
+      this.buildCarouselBackground(outputDirectory, aspectRatio, filterParams.outputDuration)
+        .then((carouselBgPath) => this.runMainRender(carouselBgPath, inputPath, ffmpegFilterComplexStr, outputPath, thumbnailPath, totalOutputFrames, res, next));
+    } else {
+      this.runMainRender(bgImagePath, inputPath, ffmpegFilterComplexStr, outputPath, thumbnailPath, totalOutputFrames, res, next);
+    }
+  }
+
+  // composites the mosaic tiles over a background (a still frame or the carousel
+  // video, both supplied as input 0) and writes the final render, emitting
+  // progress and generating the thumbnail on close.
+  private runMainRender (
+    bgInputPath: string,
+    inputPath: string,
+    filterStr: string,
+    outputPath: string,
+    thumbnailPath: string,
+    totalOutputFrames: number,
+    res: Response,
+    next: any
+  ) {
+    const proc = spawn(ffmpeg.path, ['-i', bgInputPath, '-i', inputPath, '-filter_complex', filterStr, '-preset', 'veryfast', '-crf', '26', '-map', '[out]', '-an', '-y', outputPath]);
     // @ts-ignore: Object is possibly 'null'.
     proc.stdout.on('data', function(data) {
       console.log(`proc.stdout.on('data'): ${data}`);
@@ -224,6 +257,39 @@ export default class FFmpegService {
       console.log(`renderMosaic : proc.on('close')`);
       this.generateThumbnail(outputPath, thumbnailPath).then(() => next());
     });
+  }
+
+  // Builds (and caches) the crossfading carousel background for an asset +
+  // aspect ratio: the SCRUBBER_FRAME_COUNT desaturated frames dissolved one into
+  // the next across the full render duration. Resolves to the background path.
+  private buildCarouselBackground (
+    outputDirectory: string,
+    aspectRatio: AspectRatio,
+    outputDuration: number
+  ): Promise<string> {
+    const suffix = aspectRatio === '9x16' ? '_9x16' : '';
+    const bgPath = `${outputDirectory}/bg_carousel${suffix}.mov`;
+    if (fs.existsSync(bgPath)) {
+      return Promise.resolve(bgPath);
+    }
+    const args: string[] = [];
+    const clipLen = outputDuration.toString();
+    for (let i = 1; i <= SCRUBBER_FRAME_COUNT; i++) {
+      const frameName = `img${String(i).padStart(3, '0')}${suffix}.jpg`;
+      // each frame is a full-duration layer; alpha fades decide when it shows
+      args.push('-loop', '1', '-t', clipLen, '-i', `${outputDirectory}/${frameName}`);
+    }
+    args.push(
+      '-filter_complex', createCarouselFilter(SCRUBBER_FRAME_COUNT),
+      '-map', '[out]',
+      '-t', outputDuration.toString(),
+      '-r', '25',
+      '-pix_fmt', 'yuv420p',
+      '-preset', 'veryfast',
+      '-crf', '26',
+      '-an', '-y', bgPath
+    );
+    return this.runFfmpeg(args).then(() => bgPath);
   }
 
   // grabs a single frame from a rendered video for use as an admin-report thumbnail;

--- a/mosaic-backend/lib/MosaicServices/FFmpegService/configs.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/configs.ts
@@ -5,6 +5,10 @@ import type {
   ScaleDimensions,
   PanelCount } from '../../types';
 
+// number of desaturated background frames exported per upload and cycled by the
+// carousel. Kept in sync with the frontend SCRUBBER_FRAMES_MAX (app.config.ts).
+export const SCRUBBER_FRAME_COUNT = 15;
+
 // time offset for each panel to fade in (aspect-ratio independent)
 export const FADE_IN_PRESENTATION_TIMESTAMPS: FadeInPresentationTimestamps =
   {

--- a/mosaic-backend/lib/MosaicServices/FFmpegService/utils/createCarouselFilter.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/utils/createCarouselFilter.ts
@@ -1,0 +1,40 @@
+// Builds a crossfade chain that dissolves through the desaturated background
+// frames. Mirrors the on-device carousel preview (HOLD_MS + CROSSFADE_MS in the
+// frontend Scrubber.tsx): each frame is shown solo for (ADVANCE - CROSSFADE)
+// seconds, then dissolves into the next over CROSSFADE seconds, so one frame
+// occupies ADVANCE seconds on screen.
+//
+// The bundled ffmpeg (2018 static build) predates the `xfade` filter, so the
+// dissolve is done the old way: frame 1 is an opaque base and every later frame
+// is stacked on top with `overlay`, its alpha ramped 0->1 by a `fade=in` at its
+// crossfade slot. Once opaque a layer fully covers the frame below it, and
+// before its ramp it is transparent — the ramp window is the crossfade.
+const CROSSFADE = 0.5;
+const ADVANCE = 1.0;
+
+// filter_complex for a standalone pass that turns `frameCount` looped image
+// inputs ([0:v] .. [frameCount-1:v]) into a single crossfading [out] stream.
+// The inputs must all share the output canvas size (they do: imgNNN.jpg is
+// 1080x1080 and imgNNN_9x16.jpg is 1080x1920). Assumes frameCount >= 2.
+export default function createCarouselFilter (frameCount: number): string {
+  const d = CROSSFADE.toFixed(2);
+  const statements: string[] = [`[0:v] fps=25, format=yuva420p, setsar=1 [base]`];
+
+  // input i (0-based) is frame i+1; its crossfade-in begins CROSSFADE seconds
+  // before its solo slot starts at i*ADVANCE.
+  for (let i = 1; i < frameCount; i++) {
+    const start = (i * ADVANCE - CROSSFADE).toFixed(2);
+    statements.push(`[${i}:v] fps=25, format=yuva420p, setsar=1, fade=t=in:st=${start}:d=${d}:alpha=1 [f${i}]`);
+  }
+
+  let prev = '[base]';
+  for (let i = 1; i < frameCount; i++) {
+    const outLabel = i === frameCount - 1 ? '[out]' : `[o${i}]`;
+    statements.push(`${prev}[f${i}] overlay ${outLabel}`);
+    prev = `[o${i}]`;
+  }
+
+  // joined with ';' and no trailing separator — a trailing ';' makes ffmpeg
+  // parse an empty final segment ("No such filter: ''").
+  return statements.join(';\n');
+}

--- a/mosaic-frontend/src/app.config.ts
+++ b/mosaic-frontend/src/app.config.ts
@@ -9,7 +9,7 @@ const [width, uiContainerHeight] = isMobileDevice
 const popOverHeight = width + uiContainerHeight;
 
 const MAX_VIDEO_UPLOAD_DURATION = 15;
-const SCRUBBER_FRAMES_MAX = 20
+const SCRUBBER_FRAMES_MAX = 15
 const DEFAULT_VIDEO_NUM_TILES = 4;
 
 // height multiplier applied to the (square) canvas width for each aspect ratio

--- a/mosaic-frontend/src/components/RenderMosaic/RenderMosaic.tsx
+++ b/mosaic-frontend/src/components/RenderMosaic/RenderMosaic.tsx
@@ -27,7 +27,7 @@ const RenderMosaic: React.FC<RenderMosaicProps> = ({ displaySize, isActive }) =>
   const { assetID, imageFilenames, downloadFileName } = useSelector<RootState, UploadState>((state) => state.upload);
   const { numTiles } = useSelector<RootState, Partial<MosaicState>>((state) => state.mosaic);
   const { aspectRatio } = useSelector<RootState, AppState>((state) => state.app);
-  const { currentScrubberFrame } = useSelector<RootState, ScrubberState>((state) => state.scrubber);
+  const { currentScrubberFrame, carouselMode } = useSelector<RootState, ScrubberState>((state) => state.scrubber);
   const { renderPhase, renderBlob } = useSelector<RootState, RenderState>((state) => state.render);
   const imageFilename = imageFilenames[currentScrubberFrame];
 
@@ -37,7 +37,7 @@ const RenderMosaic: React.FC<RenderMosaicProps> = ({ displaySize, isActive }) =>
       action: 'onRenderVideo',
       label: 'N/A'
     });
-    const renderUrl = `/render/mosaic/?assetID=${assetID}&numTiles=${numTiles}&currentScrubberFrame=${imageFilename}&aspectRatio=${aspectRatio}`;
+    const renderUrl = `/render/mosaic/?assetID=${assetID}&numTiles=${numTiles}&currentScrubberFrame=${imageFilename}&aspectRatio=${aspectRatio}&carousel=${carouselMode}`;
     dispatch(renderMosaic(renderUrl));
     dispatch(setAppPhase({ appPhase: AppPhaseEnum.LOADING}));
   }

--- a/mosaic-frontend/src/components/Scrubber/Scrubber.tsx
+++ b/mosaic-frontend/src/components/Scrubber/Scrubber.tsx
@@ -8,29 +8,102 @@ import { AppState } from '@interfaces/AppState';
 import { getAspectHeight } from '@/app.config';
 import '@components/Scrubber/scrubber.css';
 
+// carousel timing: hold each background frame, then dissolve into the next.
+// One frame therefore occupies HOLD_MS + CROSSFADE_MS on screen.
+const HOLD_MS = 500;
+const CROSSFADE_MS = 500;
+
 const Scrubber: React.FC<ScrubberProps> = (): React.JSX.Element => {
-  const imgRef = useRef<HTMLImageElement | null>(null);
+  const bottomImgRef = useRef<HTMLImageElement | null>(null);
+  const topImgRef = useRef<HTMLImageElement | null>(null);
   const { imageURLs, imageURLs9x16 } = useSelector<RootState, UploadState>((state) => state.upload);
   const { canvasWidth, aspectRatio } = useSelector<RootState, AppState>((state) => state.app);
-	const { currentScrubberFrame, videoUploadCount } = useSelector<RootState, ScrubberState>((state) => state.scrubber);
+  const { currentScrubberFrame, videoUploadCount, carouselMode } = useSelector<RootState, ScrubberState>((state) => state.scrubber);
   const activeImageURLs = aspectRatio === '9x16' ? imageURLs9x16 : imageURLs;
   const canvasHeight = getAspectHeight(canvasWidth, aspectRatio);
+  // the base (bottom) layer keeps the original 1:1/9:16 classes so its layout is
+  // unchanged; the overlay (top) layer sits directly over it and is crossfaded.
+  const baseClassName = aspectRatio === '9x16' ? 'scrubber-img--9x16' : '';
+  const overlayClassName = `${baseClassName} scrubber-img--overlay`.trim();
 
+  // static (slider) mode: show the manually selected frame on the bottom layer
+  // and keep the crossfade overlay hidden.
   useEffect(() => {
-		if (imgRef.current !== null) {
-			imgRef.current.src = activeImageURLs[currentScrubberFrame];
-		}
-	}, [currentScrubberFrame, videoUploadCount, aspectRatio]);
+    if (carouselMode) return;
+    const bottom = bottomImgRef.current;
+    const top = topImgRef.current;
+    if (!bottom || !top || activeImageURLs.length === 0) return;
+    bottom.src = activeImageURLs[currentScrubberFrame];
+    top.style.transition = 'none';
+    top.style.opacity = '0';
+  }, [carouselMode, currentScrubberFrame, videoUploadCount, aspectRatio, activeImageURLs]);
+
+  // carousel mode: loop through every frame. The bottom layer always shows the
+  // current frame at full opacity; the overlay fades the next frame in over it,
+  // then the bottom is swapped to that same (already fully visible) frame so the
+  // reset for the following step is seamless (no flash).
+  useEffect(() => {
+    if (!carouselMode) return;
+    const bottom = bottomImgRef.current;
+    const top = topImgRef.current;
+    const frameCount = activeImageURLs.length;
+    if (!bottom || !top || frameCount === 0) return;
+
+    let cancelled = false;
+    const timers: Array<ReturnType<typeof setTimeout>> = [];
+    let index = currentScrubberFrame % frameCount;
+
+    bottom.src = activeImageURLs[index];
+    top.style.transition = 'none';
+    top.style.opacity = '0';
+    top.src = activeImageURLs[(index + 1) % frameCount];
+
+    const runStep = () => {
+      if (cancelled) return;
+      timers.push(setTimeout(() => {
+        if (cancelled) return;
+        top.style.transition = `opacity ${CROSSFADE_MS}ms linear`;
+        void top.offsetWidth; // commit the starting opacity before transitioning
+        top.style.opacity = '1';
+        timers.push(setTimeout(() => {
+          if (cancelled) return;
+          index = (index + 1) % frameCount;
+          bottom.src = activeImageURLs[index]; // matches the now fully visible overlay
+          top.style.transition = 'none';
+          top.style.opacity = '0';
+          void top.offsetWidth;
+          top.src = activeImageURLs[(index + 1) % frameCount];
+          runStep();
+        }, CROSSFADE_MS));
+      }, HOLD_MS));
+    };
+    runStep();
+
+    return () => {
+      cancelled = true;
+      timers.forEach(clearTimeout);
+    };
+    // currentScrubberFrame is only read as the starting index; it is frozen
+    // while the slider is disabled, so it is intentionally not a restart trigger.
+  }, [carouselMode, videoUploadCount, aspectRatio, activeImageURLs]);
 
   return (
     <div className='scrubber-container'>
       { activeImageURLs.length > 0 &&
-        <img
-          ref={imgRef}
-          className={aspectRatio === '9x16' ? 'scrubber-img--9x16' : ''}
-          width={canvasWidth}
-          height={canvasHeight}
-        />
+        <>
+          <img
+            ref={bottomImgRef}
+            className={baseClassName}
+            width={canvasWidth}
+            height={canvasHeight}
+          />
+          <img
+            ref={topImgRef}
+            className={overlayClassName}
+            width={canvasWidth}
+            height={canvasHeight}
+          />
+        </>
       }
     </div>
   );

--- a/mosaic-frontend/src/components/Scrubber/scrubber.css
+++ b/mosaic-frontend/src/components/Scrubber/scrubber.css
@@ -2,3 +2,12 @@
   position: absolute;
   margin-top: 0px;
 }
+
+/* crossfade overlay sits directly over the base frame; its opacity is animated
+   in Scrubber.tsx (carousel mode) and pinned to 0 in slider mode. */
+.scrubber-img--overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}

--- a/mosaic-frontend/src/components/Scrubber/scrubber.slice.ts
+++ b/mosaic-frontend/src/components/Scrubber/scrubber.slice.ts
@@ -8,7 +8,8 @@ export const initialState: ScrubberState = {
   scrubberFramesMax: SCRUBBER_FRAMES_MAX,
   currentScrubberFrame: Math.floor(SCRUBBER_FRAMES_MAX / 2),
   canvasWidth: 0,
-  videoUploadCount: 0
+  videoUploadCount: 0,
+  carouselMode: false
 }
 
 const scrubberSlice = createSlice({
@@ -23,6 +24,9 @@ const scrubberSlice = createSlice({
     },
     setVideoUploadCount (state, action: PayloadAction<{increment: number}>) {
       state.videoUploadCount += action.payload.increment;
+    },
+    setCarouselMode (state, action: PayloadAction<{ carouselMode: boolean }>) {
+      state.carouselMode = action.payload.carouselMode;
     }
 
   }
@@ -31,7 +35,8 @@ const scrubberSlice = createSlice({
 export const {
   setScrubberCanvasWidth,
   setCurrentScrubberFrame,
-  setVideoUploadCount
+  setVideoUploadCount,
+  setCarouselMode
 } = scrubberSlice.actions;
 
 export default scrubberSlice.reducer;

--- a/mosaic-frontend/src/components/ScrubberSlider/ScrubberSlider.tsx
+++ b/mosaic-frontend/src/components/ScrubberSlider/ScrubberSlider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { RootState } from '@typescript/types';
-import { setCurrentScrubberFrame } from '@/components/Scrubber/scrubber.slice';
+import { setCurrentScrubberFrame, setCarouselMode } from '@/components/Scrubber/scrubber.slice';
 import { CurrentScrubberFrame } from '@typescript/types';
 import { ScrubberState } from '@interfaces/ScrubberState';
 import { ScrubberSliderProps } from '@interfaces/ScrubberSliderProps';
@@ -11,12 +11,13 @@ import './scrubberSlider.scss';
 
 const ScrubberSlider: React.FC<ScrubberSliderProps> = ({ width }) => {
   const dispatch = useDispatch();
-  const { currentScrubberFrame, scrubberFramesMax } = useSelector<RootState, ScrubberState>(
+  const { currentScrubberFrame, scrubberFramesMax, carouselMode } = useSelector<RootState, ScrubberState>(
     (state) => state.scrubber
   );
   const trackWidth = width - 60;
 
   const handleChange = (_: any, newValue: number | number[]) => {
+    if (carouselMode) return;
     dispatch(setCurrentScrubberFrame(newValue as CurrentScrubberFrame));
   };
 
@@ -24,8 +25,26 @@ const ScrubberSlider: React.FC<ScrubberSliderProps> = ({ width }) => {
     return `frame ${value}`;
   }
 
+  const toggleCarousel = () => {
+    dispatch(setCarouselMode({ carouselMode: !carouselMode }));
+  };
+
   return (
-    <div style={{ width: trackWidth }}>
+    <div className='scrubberSlider__row' style={{ width: trackWidth }}>
+      <button
+        type='button'
+        className={`scrubberSlider__toggle ${carouselMode ? 'scrubberSlider__toggle--active' : ''}`}
+        onClick={toggleCarousel}
+        aria-pressed={carouselMode}
+        aria-label={carouselMode ? 'Switch to slider mode' : 'Switch to carousel mode'}
+        title={carouselMode ? 'Slider mode' : 'Carousel mode'}
+      >
+        {/* slideshow / carousel icon: a centered frame flanked by its neighbours */}
+        <svg width='22' height='22' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
+          <rect x='7.5' y='5' width='9' height='14' rx='1.5' stroke='currentColor' strokeWidth='2' />
+          <path d='M4 8v8M20 8v8' stroke='currentColor' strokeWidth='2' strokeLinecap='round' />
+        </svg>
+      </button>
       <div className='scrubberSlider'>
         <Slider
           value={currentScrubberFrame}
@@ -38,6 +57,7 @@ const ScrubberSlider: React.FC<ScrubberSliderProps> = ({ width }) => {
           min={0}
           max={scrubberFramesMax - 1}
           valueLabelDisplay="auto"
+          disabled={carouselMode}
           className='scrubberSlider__slider'
         />
       </div>

--- a/mosaic-frontend/src/components/ScrubberSlider/scrubberSlider.scss
+++ b/mosaic-frontend/src/components/ScrubberSlider/scrubberSlider.scss
@@ -1,7 +1,36 @@
 @use '@sass/mosaicVariables' as *;
 @use '@sass/mosaicMixins' as *;
 
+.scrubberSlider__row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: $spacing-space-8;
+}
+
+.scrubberSlider__toggle {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: $button-border-default;
+  border-radius: $radius-radious-12;
+  background: transparent;
+  color: $mosaic-purple-dark;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+
+  &--active {
+    background: $mosaic-purple-dark;
+    color: #ffffff;
+  }
+}
+
 .scrubberSlider {
+  flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/mosaic-frontend/src/typescript/interfaces/ScrubberState.ts
+++ b/mosaic-frontend/src/typescript/interfaces/ScrubberState.ts
@@ -4,5 +4,6 @@ export interface ScrubberState {
   currentScrubberFrame: CurrentScrubberFrame,
   scrubberFramesMax: number,
   canvasWidth: number,
-  videoUploadCount: number
+  videoUploadCount: number,
+  carouselMode: boolean
 }


### PR DESCRIPTION
## Summary
Adds a **carousel** toggle next to the background-frame slider. In carousel mode the slider is disabled and the background dissolves through all 15 frames — each held ~0.5s, then a 0.5s crossfade to the next.

## Frontend
- `SCRUBBER_FRAMES_MAX` 20 → **15**
- `carouselMode` in the scrubber slice + toggle button; slider `disabled` while active
- `Scrubber` renders two stacked `<img>` layers and runs the hold/crossfade loop (seamless bottom-layer swap → no flash); works in 1:1 and 9:16
- `RenderMosaic` sends `&carousel=<bool>`

## Backend / FFmpeg
- `exportFrames` now emits exactly `SCRUBBER_FRAME_COUNT` (15) evenly-spaced frames
- `renderMosaic`: carousel branch **builds and caches** a crossfading background video per asset+aspect, then composites the tiles + white grid over it. Still path unchanged. Cache key uses a `carousel` token.
- `createCarouselFilter` builds the dissolve with `fade`(alpha)+`overlay` — the bundled 2018 ffmpeg predates the `xfade` filter.

## Verification (local dev stack)
- 1:1 carousel render: animated desaturated background + 9 tiles + tic-tac-toe grid ✓
- 9:16 carousel render: 1080×1920, 4 tiles + grid + animated background ✓
- Still (non-carousel) render: unregressed ✓
- Frontend + backend typecheck clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)