### PR TITLE
Build carousel background at half resolution to avoid OOM

### DIFF
--- a/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/FFmpegService.ts
@@ -292,7 +292,11 @@ export default class FFmpegService {
     outputDuration: number
   ): Promise<string> {
     const suffix = aspectRatio === '9x16' ? '_9x16' : '';
-    const bgPath = `${outputDirectory}/bg_carousel${suffix}.mov`;
+    const [outWidth, outHeight] = ASPECT_OUTPUT[aspectRatio].size.split('x').map(Number);
+    // 'r2' cache version: the build now composites at half resolution. Bumping
+    // the name also sidesteps any partial/corrupt bg left by an OOM-killed
+    // earlier build so it is never reused via existsSync.
+    const bgPath = `${outputDirectory}/bg_carousel_r2${suffix}.mov`;
     // already built (only ever appears complete: written to .tmp then renamed)
     if (fs.existsSync(bgPath)) {
       return Promise.resolve(bgPath);
@@ -314,7 +318,7 @@ export default class FFmpegService {
       args.push('-loop', '1', '-t', clipLen, '-i', `${outputDirectory}/${frameName}`);
     }
     args.push(
-      '-filter_complex', createCarouselFilter(SCRUBBER_FRAME_COUNT, outputDuration),
+      '-filter_complex', createCarouselFilter(SCRUBBER_FRAME_COUNT, outputDuration, outWidth, outHeight),
       '-map', '[out]',
       '-t', outputDuration.toString(),
       '-r', '25',

--- a/mosaic-backend/lib/MosaicServices/FFmpegService/utils/createCarouselFilter.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/utils/createCarouselFilter.ts
@@ -9,30 +9,47 @@
 // is stacked on top with `overlay`, its alpha ramped 0->1 by a `fade=in` at its
 // crossfade slot. Once opaque a layer fully covers the frame below it, and
 // before its ramp it is transparent — the ramp window is the crossfade.
+//
+// Compositing runs at HALF resolution and the [out] stream stays half-size: with
+// 15 simultaneous 1080p (or 1080x1920) layers a full-res graph peaks around 1GB
+// of RSS and gets OOM-killed on a small instance. The main render scales this
+// background back up to the canvas when it composites the tiles (a no-op for the
+// full-res still path), so the build never touches full resolution. The
+// background is desaturated and sits behind the mosaic tiles, so the upscale
+// softness is invisible while memory drops ~4x.
 const CROSSFADE = 0.5;
 const ADVANCE = 1.0;
 
+// half of the output canvas, kept even for yuv420p. Exported so the main render
+// (createFfmpegFilterComplexStr) upscales the carousel background from exactly
+// the same working size the build produced.
+export function carouselWorkSize (outWidth: number, outHeight: number): { workW: number; workH: number } {
+  return { workW: 2 * Math.round(outWidth / 4), workH: 2 * Math.round(outHeight / 4) };
+}
+
 // filter_complex for a standalone pass that turns `frameCount` looped image
 // inputs ([0:v] .. [frameCount-1:v]) into a single crossfading [out] stream of
-// `duration` seconds. The inputs must all share the output canvas size (they
-// do: imgNNN.jpg is 1080x1080 and imgNNN_9x16.jpg is 1080x1920). Assumes
-// frameCount >= 2.
-export default function createCarouselFilter (frameCount: number, duration: number): string {
+// `duration` seconds at HALF of `outWidth`x`outHeight`. The inputs must all
+// share the output canvas size (imgNNN.jpg is 1080x1080, imgNNN_9x16.jpg is
+// 1080x1920). Assumes frameCount >= 2.
+export default function createCarouselFilter (frameCount: number, duration: number, outWidth: number, outHeight: number): string {
   const d = CROSSFADE.toFixed(2);
-  const statements: string[] = [`[0:v] fps=25, format=yuva420p, setsar=1 [base]`];
+  const { workW, workH } = carouselWorkSize(outWidth, outHeight);
+  const prep = `scale=${workW}:${workH}, fps=25, format=yuva420p, setsar=1`;
+
+  const statements: string[] = [`[0:v] ${prep} [base]`];
 
   // input i (0-based) is frame i+1; its crossfade-in begins CROSSFADE seconds
   // before its solo slot starts at i*ADVANCE.
   for (let i = 1; i < frameCount; i++) {
     const start = (i * ADVANCE - CROSSFADE).toFixed(2);
-    statements.push(`[${i}:v] fps=25, format=yuva420p, setsar=1, fade=t=in:st=${start}:d=${d}:alpha=1 [f${i}]`);
+    statements.push(`[${i}:v] ${prep}, fade=t=in:st=${start}:d=${d}:alpha=1 [f${i}]`);
   }
 
   // Each layer only needs to be composited from when it starts fading in until
   // the next frame has fully covered it (one ADVANCE later); the last frame
   // stays to the end. Gating overlay with `enable` skips compositing outside
-  // that ~1.5s window, so the pass stays cheap instead of blending every layer
-  // across the whole clip.
+  // that ~1.5s window.
   let prev = '[base]';
   for (let i = 1; i < frameCount; i++) {
     const winStart = (i * ADVANCE - CROSSFADE).toFixed(2);

--- a/mosaic-backend/lib/MosaicServices/FFmpegService/utils/createFfmpegFilterComplexStr.ts
+++ b/mosaic-backend/lib/MosaicServices/FFmpegService/utils/createFfmpegFilterComplexStr.ts
@@ -26,9 +26,12 @@ export const createFfmpegFilterComplexStr =  ({
 
   /////////////////////////////
   // CREATE BASE AND BG
+  // scale input 0 to the canvas: a no-op for the full-res still background, and
+  // the upscale for the half-res carousel background (built small to stay within
+  // memory — see createCarouselFilter).
   ffmpegFilterComplexStr += `nullsrc=size=${outputSize}:duration=${outputDuration}:rate=${outputFps} [base];\n`;
   //ffmpegFilterComplexStr += `[0:v] ${preCropStr}trim=start=${bgFrameStart}:duration=0.05, setpts=PTS-STARTPTS${bgFrameHue} [bg_frame];\n`;
-  ffmpegFilterComplexStr += `[0:v]${bgFrameHue}[bg_frame];\n`;
+  ffmpegFilterComplexStr += `[0:v]${bgFrameHue},scale=${outputWidth}:${outputHeight}[bg_frame];\n`;
   ffmpegFilterComplexStr += `[base][bg_frame] overlay [bg];\n`;
 
 


### PR DESCRIPTION
## Why
The 9:16 carousel background build (15 simultaneous **1080×1920** layers) peaked at **~1 GB RSS** and was OOM-killed on the production instance — the FFmpeg child died instantly, so the render fast-failed with a 404. This is also what overloaded the instance earlier. The 1:1 build (~half the pixels) squeaked by; the **default 9:16 aspect did not** — meaning 9:16 carousel couldn't build in prod for the demo *or* new uploads.

## Fix
- **Half-res compositing:** `createCarouselFilter` composites at half resolution and emits a half-size `[out]`. Peak RSS drops **~1 GB → ~330 MB (9:16) / ~200 MB (1:1)**.
- **Upscale in the main render:** input 0 is scaled to the canvas in the main filter — a **no-op for the full-res still background**, the upscale for the half-res carousel background. The build never touches full resolution; the still path is unchanged.
- **Cache version bump** (`bg_carousel_r2*`) so any partial/corrupt background left by an OOM-killed build is never reused via `existsSync`.

The background is desaturated and sits behind the tiles, so the upscale softness is invisible.

## Verification (local)
- 1:1 & 9:16 **still** + **carousel** renders all correct (dimensions + visuals) ✓
- 9:16 build peak **329 MB** (was 1021 MB) ✓
- Versioned bg produced via temp→rename, no leftover `.tmp` ✓
- Backend typecheck clean ✓

Follow-up to #63 / #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)